### PR TITLE
sy_feature UserController 인터페이스 분리, SwaggerConfig 그룹 지정 해제

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
@@ -18,15 +18,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Tag(name="User", description="사용자 API")
+@Tag(name="user-controller", description="회원 API")
 @RestController
 @RequestMapping("/users")
-public class UserApiController {
+public class UserApiController implements UserSpecification{
 
-    @Operation(summary = "모임 회원 조회", description = "특정 모임에 속한 회원을 조회한다. [이벤트 상세 > 참여자 목록]")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
-                    content = {@Content(mediaType = "application/json", array=@ArraySchema(schema=@Schema(implementation = EventUserDto.class)))})})
     @GetMapping("/event/{eventId}")
     public List<EventUserDto> getUserByEvent(@Parameter(name="eventId", description = "모임 ID", example = "1") @PathVariable("eventID") Long eventId){
         //return List<EventUserDto>
@@ -39,98 +35,21 @@ public class UserApiController {
         list.add(eventUserDto);
 
         return list;
-
-
     }
 
-    @Operation(summary = "마이페이지 회원 조회", description = "본인 정보를 가져온다. [마이페이지]")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
-                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = MyInfoDto.class))})})
     @GetMapping("/my-page/{userId}")
     public void getMyInfoById(@Parameter(name = "userId", description = "회원 ID", example = "1") @PathVariable("userId") Long userId){
         //return MyInfoDto
     }
-
-    @Operation(summary = "회원 등록", description = "새로운 회원 정보를 저장한다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
-                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = UserSaveRequestDto.class))})})
 
     @PostMapping("/")
     public void saveUser(@RequestBody UserSaveRequestDto userSaveRequestDto){
         //return Long
     }
 
-    @Operation(summary = "회원 수정", description = "회원 정보를 수정한다. [프로필 편집]")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
-                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = UserUpdateRequestDto.class))})})
-
-    @PatchMapping("/{userId}")
+   @PatchMapping("/{userId}")
     public void editUser(@Parameter(name = "userId", description = "회원 ID", example = "1") @PathVariable("userId") Long userId, @RequestBody UserUpdateRequestDto userUpdateDto){
-        //return
+        //return Long
     }
 
-    @Getter
-    @Setter
-    @Schema(description="특정 모임에 속한 회원")
-    public static class EventUserDto{
-        @Schema(description = "이름", example = "김철수", required = true)
-        private String name;
-        @Schema(description = "성별", example = "M", required = true)
-        private Gender gender;
-        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.", required = true)
-        private String introduction;
-    }
-
-    @Getter
-    @Setter
-    @Schema(description = "마이페이지 회원 정보")
-    public static class MyInfoDto{
-        @Schema(description = "이름", example = "김철수", required=true)
-        private String name;
-        @Schema(description = "성별", example = "M", required=true)
-        private Gender gender;
-        @Schema(description = "생년월일", example = "1999-05-22", required=true)
-        private String birth;
-        @Schema(description = "성격유형", example = "ISTP")
-        private String character;
-        @Schema(description = "참여 모임", example = "")
-        private List<Event> joinEvents;
-        @Schema(description = "북마크 모임", example = "김철수")
-        private List<Event> bookmarkEvents;
-    }
-    @Getter
-    @Setter
-    @Schema(description = "회원 등록")
-    public static class UserSaveRequestDto {
-        @Schema(description = "이름", example = "김철수", required=true)
-        private String name;
-        @Schema(description = "성별", example = "M", required=true)
-        private Gender gender;
-        @Schema(description = "이메일", example = "cheolsukim@lems.com")
-        private String email;
-        @Schema(description = "생년월일", example = "1999-05-22", required=true)
-        private String birth;
-        @Schema(description = "지역명", example = "서울시", required=true)
-        private String local_name;
-        @Schema(description = "성격유형", example = "ISTP")
-        private String character;
-        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.")
-        private String introduction;
-    }
-    @Getter
-    @Setter
-    @Schema(description = "회원 수정")
-    public static class UserUpdateRequestDto {
-        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.")
-        private String introduction;
-        @Schema(description = "지역명", example = "서울시", required=true)
-        private String local_name;
-        @Schema(description = "생년월일", example = "1999-05-22", required=true)
-        private String birth;
-        @Schema(description = "성격유형", example = "ISTP")
-        private String character;
-    }
 }

--- a/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
@@ -1,0 +1,102 @@
+package lems.cowshed.api.controller.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.user.Gender;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public interface UserSpecification {
+    @Operation(summary = "모임 회원 조회", description = "특정 모임에 속한 회원을 조회한다. [이벤트 상세 > 참여자 목록]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
+                    content = {@Content(mediaType = "application/json", array=@ArraySchema(schema=@Schema(implementation = EventUserDto.class)))})})
+
+    List<EventUserDto> getUserByEvent(Long eventId);
+
+    @Operation(summary = "마이페이지 회원 조회", description = "본인 정보를 가져온다. [마이페이지]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
+                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = MyInfoDto.class))})})
+    void getMyInfoById(Long userId);
+
+    @Operation(summary = "회원 등록", description = "새로운 회원 정보를 저장한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
+                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = UserSaveRequestDto.class))})})
+    void saveUser(UserSaveRequestDto userSaveRequestDto);
+
+    @Operation(summary = "회원 수정", description = "회원 정보를 수정한다. [프로필 편집]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "200 ok 요청이 성공적으로 처리되었습니다.",
+                    content = {@Content(mediaType = "application/json", schema=@Schema(implementation = UserUpdateRequestDto.class))})})
+    void editUser(Long userId, UserUpdateRequestDto userUpdateRequestDto);
+
+    @Getter
+    @Setter
+    @Schema(description="특정 모임에 속한 회원")
+    public static class EventUserDto{
+        @Schema(description = "이름", example = "김철수", required = true)
+        private String name;
+        @Schema(description = "성별", example = "M", required = true)
+        private Gender gender;
+        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.", required = true)
+        private String introduction;
+    }
+    @Getter
+    @Setter
+    @Schema(description = "마이페이지 회원 정보")
+    public static class MyInfoDto{
+        @Schema(description = "이름", example = "김철수", required=true)
+        private String name;
+        @Schema(description = "성별", example = "M", required=true)
+        private Gender gender;
+        @Schema(description = "생년월일", example = "1999-05-22", required=true)
+        private String birth;
+        @Schema(description = "성격유형", example = "ISTP")
+        private String character;
+        @Schema(description = "참여 모임", example = "")
+        private List<Event> joinEvents;
+        @Schema(description = "북마크 모임", example = "김철수")
+        private List<Event> bookmarkEvents;
+    }
+    @Getter
+    @Setter
+    @Schema(description = "회원 등록")
+    public static class UserSaveRequestDto {
+        @Schema(description = "이름", example = "김철수", required=true)
+        private String name;
+        @Schema(description = "성별", example = "M", required=true)
+        private Gender gender;
+        @Schema(description = "이메일", example = "cheolsukim@lems.com")
+        private String email;
+        @Schema(description = "생년월일", example = "1999-05-22", required=true)
+        private String birth;
+        @Schema(description = "지역명", example = "서울시", required=true)
+        private String local_name;
+        @Schema(description = "성격유형", example = "ISTP")
+        private String character;
+        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.")
+        private String introduction;
+    }
+    @Getter
+    @Setter
+    @Schema(description = "회원 수정")
+    public static class UserUpdateRequestDto {
+        @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.")
+        private String introduction;
+        @Schema(description = "지역명", example = "서울시", required=true)
+        private String local_name;
+        @Schema(description = "생년월일", example = "1999-05-22", required=true)
+        private String birth;
+        @Schema(description = "성격유형", example = "ISTP")
+        private String character;
+    }
+}

--- a/src/main/java/lems/cowshed/config/SwaggerConfig.java
+++ b/src/main/java/lems/cowshed/config/SwaggerConfig.java
@@ -29,23 +29,23 @@ public class SwaggerConfig {
     @Value("${lems.openapi.prod-url}")
     private String prodUrl;
 
-    @Bean
-    public GroupedOpenApi userApi(){
-        return GroupedOpenApi.builder()
-                .group("user")
-                .pathsToMatch("/users/**")
+//    @Bean
+//    public GroupedOpenApi userApi(){
+//        return GroupedOpenApi.builder()
+//                .group("user")
+//                .pathsToMatch("/users/**")
 //                .addOpenApiCustomizer(apiResponsesCustomizer())
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi eventApi(){
-        return GroupedOpenApi.builder()
-                .group("event")
-                .pathsToMatch("/events/**")
+//                .build();
+//    }
+//
+//    @Bean
+//    public GroupedOpenApi eventApi(){
+//        return GroupedOpenApi.builder()
+//                .group("event")
+//                .pathsToMatch("/events/**")
 //                .addOpenApiCustomizer(apiResponsesCustomizer())
-                .build();
-    }
+//                .build();
+//    }
 
     @Bean
     public OpenAPI metaData() {


### PR DESCRIPTION
# UserSpecification 인터페이스 생성
- UserApiController에 있던 Swagger 어노테이션들을 UserSpecification 인터페이스로 분리하였습니다.
- Dto도 구현체가 아닌 인터페이스에 포함시켰습니다.

# SwaggerConfig 수정
- Swagger-UI 페이지를 user, event 두 그룹으로 나누면 https://syoung522.github.io/lems-swagger-ui/dist 페이지 또한 두 개로 나누어져야하기 때문에, 그룹을 없애고 한 페이지에 user, event를 모두 나타내도록 변경했습니다.
![image](https://github.com/user-attachments/assets/cdac3e52-d112-44bc-8161-d46c2b467bce)
