### PR TITLE
로그인 JWT 토큰 구현, url 요청 시 검증 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
+
+	//MySql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//JWT 의존성
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/lems/cowshed/api/controller/login/AdminController.java
+++ b/src/main/java/lems/cowshed/api/controller/login/AdminController.java
@@ -1,0 +1,14 @@
+package lems.cowshed.api.controller.login;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminController {
+
+    @GetMapping("/admin")
+    public String adminP(){
+            return "Admin Controller";
+        }
+
+}

--- a/src/main/java/lems/cowshed/api/controller/login/JoinController.java
+++ b/src/main/java/lems/cowshed/api/controller/login/JoinController.java
@@ -1,0 +1,22 @@
+package lems.cowshed.api.controller.login;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class JoinController {
+
+    private final JoinService joinservice;
+
+    @PostMapping("/join")
+    public String joinProcess(@RequestBody JoinDto joinDto){
+        joinservice.JoinProcess(joinDto);
+        return "ok";
+    }
+
+}

--- a/src/main/java/lems/cowshed/api/controller/login/JoinDto.java
+++ b/src/main/java/lems/cowshed/api/controller/login/JoinDto.java
@@ -1,0 +1,11 @@
+package lems.cowshed.api.controller.login;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class JoinDto {
+    private String username;
+    private String password;
+}

--- a/src/main/java/lems/cowshed/api/controller/login/JoinService.java
+++ b/src/main/java/lems/cowshed/api/controller/login/JoinService.java
@@ -1,0 +1,29 @@
+package lems.cowshed.api.controller.login;
+
+import lems.cowshed.domain.user.User;
+import lems.cowshed.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class JoinService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public void JoinProcess(JoinDto joinDto) {
+        String username = joinDto.getUsername();
+        String password = joinDto.getPassword();
+
+        if(userRepository.findByName(username).isPresent()){
+            new IllegalArgumentException("User name equals exist");
+        };
+
+        User data = User.createUser(username, bCryptPasswordEncoder.encode(password),"ROLE_ADMIN");
+        userRepository.save(data);
+    }
+}

--- a/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lems.cowshed.domain.event.Event;
+/*import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.user.Gender;
-import lems.cowshed.domain.user.User;
+import lems.cowshed.domain.user.User;*/
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.bind.annotation.*;
@@ -101,6 +101,7 @@ public class UserApiController {
         @Schema(description = "북마크 모임", example = "김철수")
         private List<Event> bookmarkEvents;
     }
+
     @Getter
     @Setter
     @Schema(description = "회원 등록")
@@ -120,6 +121,7 @@ public class UserApiController {
         @Schema(description = "소개", example = "성남시 분당구에 사는 직장인입니다.")
         private String introduction;
     }
+
     @Getter
     @Setter
     @Schema(description = "회원 수정")

--- a/src/main/java/lems/cowshed/config/jwt/JwtFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/JwtFilter.java
@@ -1,0 +1,71 @@
+package lems.cowshed.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lems.cowshed.domain.user.User;
+import lems.cowshed.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //request에서 Authorization 헤더를 찾음
+        String authorization= request.getHeader("Authorization");
+
+        //Authorization 헤더 검증
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        System.out.println("authorization now");
+        //Bearer 부분 제거 후 순수 토큰만 획득
+        String token = authorization.split(" ")[1];
+
+        //토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰에서 username과 role 획득
+        String username = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+
+        //userEntity를 생성하여 값 set
+        User user = User.createUser(username,"tempPass",role);
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
+++ b/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
@@ -1,0 +1,42 @@
+package lems.cowshed.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}")String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String username, String role, Long expiredMs) {
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
@@ -1,0 +1,82 @@
+package lems.cowshed.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lems.cowshed.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        String username = null;
+        String password = null;
+
+        if(request.getContentType().equals("application/json")) {
+            try {
+                BufferedReader reader = request.getReader();
+                Map<String, String> jsonMap = objectMapper.readValue(reader, Map.class);
+
+                username = jsonMap.get("username");
+                password = jsonMap.get("password");
+
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read Json");
+            }
+        }
+        else{
+            throw new RuntimeException("ContentType only application/json");
+        }
+
+        // username, password, roll 값을 통해 token 만들고 authenticationManager 인증 요청
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    //로그인 성공 시 jwt 토큰 발행
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+        String token = jwtUtil.createJwt(username, role, 60 * 60 * 1000L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+
+    }
+
+    //로그인 실패 시
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/lems/cowshed/config/jwt/SecurityConfig.java
+++ b/src/main/java/lems/cowshed/config/jwt/SecurityConfig.java
@@ -1,0 +1,76 @@
+package lems.cowshed.config.jwt;
+
+import lems.cowshed.config.jwt.LoginFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    //인증 설정 클래스
+    private final AuthenticationConfiguration authenticationConfiguration;
+    //jwt 생성 클래스
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception{
+        return configuration.getAuthenticationManager();
+    }
+
+    // 암호화
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // FilterChainProxy 등록 되는 chain 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //폼 로그인 방식 사용x
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //http basic 인증 방식 사용x
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        // http 인증 url
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/login", "/", "/join").permitAll()
+                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .anyRequest().authenticated());
+
+        // 로그인 필터 등록
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        //jwt 필터 등록
+        http
+                .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+
+        //세션 설정
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/lems/cowshed/domain/user/User.java
+++ b/src/main/java/lems/cowshed/domain/user/User.java
@@ -1,0 +1,31 @@
+package lems.cowshed.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String name;
+    private String password;
+    private String role;
+
+    protected User() {}
+
+    public static User createUser(String name, String password, String role) {
+        User user = new User();
+        user.name = name;
+        user.password = password;
+        user.role = role;
+
+        return user;
+    }
+}

--- a/src/main/java/lems/cowshed/domain/user/UserRepository.java
+++ b/src/main/java/lems/cowshed/domain/user/UserRepository.java
@@ -1,0 +1,25 @@
+package lems.cowshed.domain.user;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepository {
+
+    private final EntityManager em;
+
+    public void save(User user){
+        em.persist(user);
+    }
+
+    public Optional<User> findByName(String name){
+        return em.createQuery("select u from User u where u.name = :name", User.class)
+                .setParameter("name", name)
+                .getResultStream().findAny();
+    }
+}

--- a/src/main/java/lems/cowshed/service/CustomUserDetails.java
+++ b/src/main/java/lems/cowshed/service/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package lems.cowshed.service;
+
+import lems.cowshed.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+}

--- a/src/main/java/lems/cowshed/service/CustomUserDetailsService.java
+++ b/src/main/java/lems/cowshed/service/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package lems.cowshed.service;
+
+import lems.cowshed.domain.user.User;
+import lems.cowshed.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Optional<User> optionalUser = userRepository.findByName(username);
+
+        User user = optionalUser.orElseThrow(
+                () -> new IllegalStateException("user not exist"));
+
+        return new CustomUserDetails(user);
+    }
+}


### PR DESCRIPTION
##
### 🌱 PR 타입
[feat] : 로그인 JWT 토큰 발급, 요청 시 권한 확인
##

### 🌱 구현 사항
1.  회원 가입을 구현 했습니다.
2.  로그인 하면 JWT 토큰을 발급 합니다.
3.  유저에 따라 접근 권한을 설정 했습니다.

##
### 🌱 회원 가입
1. JoinController 에서 Json을 받아 Joinservice에서 같은 이름이 있는지 체크 후 DB에 user를 저장 합니다.

##
### 📝 Authorization ( 인가 )
![image](https://github.com/user-attachments/assets/b8b78693-b502-4bc4-864e-01f313cf2d90)
1. permitAll() : 모든 요청을 허용 합니다.
2. hasRole("ADMIN") : Role "ADMIN"인 유저만 허용 합니다.
3. anyRequest().authenticated() : 그 외는 인증된 유저만 허용 합니다. 

##
###  📝 Authentication( 인증 )
![image](https://github.com/user-attachments/assets/666e7b83-b7f9-4c1a-868d-1850de985456)
1. UserNamePasswordAuthenticationFilter를 커스텀 하여 JWT 토큰을 발급 하는 필터를 구현 합니다.
2. AuthenticationManager는  token을 통해 UserDetailservice에 인증을 요청 합니다.
3. UserDetailservice는 같은 이름이 있는 유저를 체크 한후 UserDetails를 반환 합니다.
4. UserDetails는 인증된 유저의 정보를 가지고 있습니다.
5. 로그인에 성공 시 successfulAuthentication() 메소드가 실행 됩니다.
6. 이름, role을 jwtUtil에 넘겨 토큰을 만들고 header에 토큰을 추가 합니다.  

##
### 🌱 회원 가입
![image](https://github.com/user-attachments/assets/a7328ea8-1bb1-4909-a028-c8e634ebfd18)
![image](https://github.com/user-attachments/assets/9eb1d867-fd2d-4b2d-9a42-6ae1f70baf75)

##
### 🌱 로그인
![image](https://github.com/user-attachments/assets/713c24e8-b73a-4443-a947-0d90f331a114)

##
### 🌱 토큰 검증
성공
![image](https://github.com/user-attachments/assets/034dcda1-025d-4ccd-bdc8-62f24e962501)

##
실패
![image](https://github.com/user-attachments/assets/1acd5376-250d-4da7-9e36-723caa529c4f)

