### PR TITLE
Feature/user test and fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+out/
+build/
+.idea/
+.gradle/
+application.yml
+application.properties
+src/main/generated/

--- a/src/main/java/lems/cowshed/api/advice/GeneralAdvice.java
+++ b/src/main/java/lems/cowshed/api/advice/GeneralAdvice.java
@@ -1,6 +1,7 @@
 package lems.cowshed.api.advice;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lems.cowshed.exception.UserLoginException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/lems/cowshed/api/advice/user/UserAdvice.java
+++ b/src/main/java/lems/cowshed/api/advice/user/UserAdvice.java
@@ -1,8 +1,11 @@
 package lems.cowshed.api.advice.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lems.cowshed.exception.BusinessException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
+@Order(0)
 @RestControllerAdvice(basePackages = "lems.cowshed.api.controller.user")
 public class UserAdvice {
 
@@ -24,6 +29,13 @@ public class UserAdvice {
                 .collect(Collectors.toList());
 
         return new UserErrorResult(errorMessages);
+    }
+
+    @ExceptionHandler(value = {BusinessException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public UserErrorResult userBusinessHandler(BusinessException ex){
+        log.info("예외 메시지 : {}", ex.getMessage(), ex);
+        return new UserErrorResult(List.of(new UserErrorMessage(ex.getReason(), ex.getMessage())));
     }
 
     @Getter

--- a/src/main/java/lems/cowshed/api/controller/SecurityContextUtil.java
+++ b/src/main/java/lems/cowshed/api/controller/SecurityContextUtil.java
@@ -4,7 +4,7 @@ import lems.cowshed.service.CustomUserDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-public class UserUtils {
+public class SecurityContextUtil {
     public static Long getUserId(){
         CustomUserDetails principal = getCurrentUserDetails();
         return (principal != null) ? principal.getUserId() : null;

--- a/src/main/java/lems/cowshed/api/controller/dto/user/request/UserEditRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/request/UserEditRequestDto.java
@@ -3,15 +3,13 @@ package lems.cowshed.api.controller.dto.user.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lems.cowshed.domain.user.Gender;
 import lems.cowshed.domain.user.Mbti;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Getter @Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "회원 수정")
 public class UserEditRequestDto {
 
@@ -39,5 +37,4 @@ public class UserEditRequestDto {
         this.character = character;
     }
 
-    public UserEditRequestDto(){}
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/user/request/UserLoginRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/request/UserLoginRequestDto.java
@@ -2,6 +2,7 @@ package lems.cowshed.api.controller.dto.user.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
@@ -14,4 +15,10 @@ public class UserLoginRequestDto {
     @Schema(description = "비밀번호", example = "1234")
     @NotBlank
     private String password;
+
+    @Builder
+    public UserLoginRequestDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/user/request/UserSaveRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/request/UserSaveRequestDto.java
@@ -2,22 +2,25 @@ package lems.cowshed.api.controller.dto.user.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import lems.cowshed.domain.user.Role;
+import lems.cowshed.domain.user.User;
 import lombok.*;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Getter @Setter
 @NoArgsConstructor
 public class UserSaveRequestDto {
+
     @Schema(description = "이메일", example = "test1234@naver.com")
-    @NotBlank
+    @NotBlank(message = "이메일 값은 필수 입니다.")
     private String email;
 
     @Schema(description = "닉네임", example = "외양간")
-    @NotBlank
+    @NotBlank(message = "유저 닉네임은 필수 입니다.")
     private String username;
 
     @Schema(description = "비밀번호", example = "****")
-    @NotBlank
+    @NotBlank(message = "패스워드는 필수 입니다.")
     private String password;
 
     @Builder
@@ -25,5 +28,14 @@ public class UserSaveRequestDto {
         this.email = email;
         this.username = username;
         this.password = password;
+    }
+
+    public User toEntityForRegister(BCryptPasswordEncoder bCryptPasswordEncoder, Role role){
+        return User.builder()
+                .username(username)
+                .password(bCryptPasswordEncoder.encode(password))
+                .email(email)
+                .role(role)
+                .build();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
@@ -1,9 +1,11 @@
 package lems.cowshed.api.controller.dto.user.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lems.cowshed.domain.user.Mbti;
 import lems.cowshed.domain.user.query.UserEventMyPageQueryDto;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Data
@@ -14,10 +16,10 @@ public class UserMyPageResponseDto {
     private String name;
 
     @Schema(description = "생년월일", example = "1999-05-22")
-    private String birth;
+    private LocalDate birth;
 
     @Schema(description = "성격유형", example = "ISTP")
-    private String character;
+    private Mbti character;
 
     @Schema(description = "참여 모임")
     private List<UserEventMyPageQueryDto> userEventList;

--- a/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
@@ -1,5 +1,7 @@
 package lems.cowshed.api.controller.user;
 
+import jakarta.validation.Valid;
+import lems.cowshed.api.controller.SecurityContextUtil;
 import lems.cowshed.api.controller.dto.CommonResponse;
 import lems.cowshed.api.controller.dto.user.request.UserEditRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserLoginRequestDto;
@@ -18,26 +20,29 @@ import java.time.LocalDate;
 public class UserApiController implements UserSpecification{
 
     private final UserService userService;
+    private final Long userId = SecurityContextUtil.getUserId();
 
     @PostMapping("/login")
     public CommonResponse<Void> login(@RequestBody UserLoginRequestDto userLoginRequestDto){
+        userService.login(userLoginRequestDto);
         return CommonResponse.customMessage("로그인 성공");
     }
 
+    //TODO
     @GetMapping
     public CommonResponse<UserMyPageResponseDto> userMyPage(){
         return null;
     }
 
     @PostMapping("/register")
-    public CommonResponse<Void> saveUser(@RequestBody UserSaveRequestDto userSaveRequestDto) {
+    public CommonResponse<Void> saveUser(@Valid @RequestBody UserSaveRequestDto userSaveRequestDto) {
         userService.JoinProcess(userSaveRequestDto);
         return CommonResponse.success();
     }
 
     @PatchMapping
     public CommonResponse<Void> editUser(@RequestBody UserEditRequestDto userEditRequestDto){
-        userService.editProcess(userEditRequestDto);
+        userService.editProcess(userEditRequestDto, userId);
         return CommonResponse.customMessage("유저 변경 성공");
     }
 

--- a/src/main/java/lems/cowshed/config/jwt/JwtFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/JwtFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lems.cowshed.domain.user.Role;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -52,9 +53,9 @@ public class JwtFilter extends OncePerRequestFilter {
         Long userId = jwtUtil.getUserId(token);
         String email = jwtUtil.getUserEmail(token);
         String username = jwtUtil.getUsername(token);
-        String role = jwtUtil.getRole(token);
+        Role role = jwtUtil.getRole(token);
 
-        User user = User.createUserForDetails(userId, username, "tempPass", role, email);
+        User user = User.createUserForDetails(userId, username, "tempPass", Role.ROLE_USER, email);
 
         //UserDetails에 회원 정보 객체 담기
         CustomUserDetails customUserDetails = new CustomUserDetails(user);

--- a/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
+++ b/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package lems.cowshed.config.jwt;
 
 import io.jsonwebtoken.Jwts;
+import lems.cowshed.domain.user.Role;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -30,8 +31,8 @@ public class JwtUtil {
         return  Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
-    public String getRole(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    public Role getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", Role.class);
     }
 
     public Boolean isExpired(String token) {

--- a/src/main/java/lems/cowshed/domain/user/Role.java
+++ b/src/main/java/lems/cowshed/domain/user/Role.java
@@ -1,0 +1,5 @@
+package lems.cowshed.domain.user;
+
+public enum Role {
+    ROLE_USER
+}

--- a/src/main/java/lems/cowshed/domain/user/User.java
+++ b/src/main/java/lems/cowshed/domain/user/User.java
@@ -23,7 +23,8 @@ public class User {
 
     private String password;
 
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
@@ -47,7 +48,7 @@ public class User {
     private LocalDateTime lastModifiedDate;
 
     @Builder
-    private User(Long id, String username, String password, String role, String email) {
+    private User(Long id, String username, String password, Role role, String email) {
         this.id = id;
         this.username = username;
         this.password = password;
@@ -55,16 +56,7 @@ public class User {
         this.email = email;
     }
 
-    public static User registerUser(String username, String password, String email, String role) {
-        return User.builder()
-                .username(username)
-                .password(password)
-                .email(email)
-                .role(role)
-                .build();
-    }
-
-    public static User createUserForDetails(Long id, String username, String password, String role, String email) {
+    public static User createUserForDetails(Long id, String username, String password, Role role, String email) {
         return User.builder()
                 .id(id)
                 .username(username)
@@ -74,12 +66,13 @@ public class User {
                 .build();
     }
 
-    public void modifyDetails(UserEditRequestDto userEditRequestDto){
-        this.username = userEditRequestDto.getUsername();
-        this.introduction = userEditRequestDto.getIntroduction();
-        this.location = userEditRequestDto.getLocalName();
-        this.birth = userEditRequestDto.getBirth();
-        this.mbti = userEditRequestDto.getCharacter();
+    //TODO
+    public void modifyContents(UserEditRequestDto userEditRequestDto){
+        if(userEditRequestDto.getUsername() != null) {this.username = userEditRequestDto.getUsername();}
+        if(userEditRequestDto.getIntroduction() != null) {this.introduction = userEditRequestDto.getIntroduction();}
+        if(userEditRequestDto.getLocalName() != null) {this.location = userEditRequestDto.getLocalName();}
+        if(userEditRequestDto.getBirth() != null) {this.birth = userEditRequestDto.getBirth();}
+        if(userEditRequestDto.getCharacter() != null) {this.mbti = userEditRequestDto.getCharacter();}
     }
 
 }

--- a/src/main/java/lems/cowshed/exception/BusinessException.java
+++ b/src/main/java/lems/cowshed/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package lems.cowshed.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends IllegalArgumentException{
+
+    private final HttpStatus httpStatus;
+    private final String reason;
+
+    public BusinessException(HttpStatus httpStatus, String reason, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/lems/cowshed/exception/DuplicateUsernameException.java
+++ b/src/main/java/lems/cowshed/exception/DuplicateUsernameException.java
@@ -1,7 +1,0 @@
-package lems.cowshed.exception;
-
-public class DuplicateUsernameException extends RuntimeException{
-    public DuplicateUsernameException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/lems/cowshed/exception/UserEditException.java
+++ b/src/main/java/lems/cowshed/exception/UserEditException.java
@@ -1,0 +1,12 @@
+package lems.cowshed.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public class UserEditException extends BusinessException {
+
+    public UserEditException(HttpStatus httpStatus, String reason, String message) {
+        super(httpStatus, reason, message);
+    }
+
+}

--- a/src/main/java/lems/cowshed/exception/UserLoginException.java
+++ b/src/main/java/lems/cowshed/exception/UserLoginException.java
@@ -1,0 +1,10 @@
+package lems.cowshed.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserLoginException extends BusinessException {
+
+    public UserLoginException(HttpStatus httpStatus, String reason, String message) {
+        super(httpStatus, reason, message);
+    }
+}

--- a/src/main/java/lems/cowshed/exception/UserNotFoundException.java
+++ b/src/main/java/lems/cowshed/exception/UserNotFoundException.java
@@ -1,7 +1,0 @@
-package lems.cowshed.exception;
-
-public class UserNotFoundException extends RuntimeException{
-    public UserNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/lems/cowshed/exception/UserRegisterException.java
+++ b/src/main/java/lems/cowshed/exception/UserRegisterException.java
@@ -1,0 +1,10 @@
+package lems.cowshed.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserRegisterException extends BusinessException {
+
+    public UserRegisterException(HttpStatus httpStatus, String reason, String message) {
+        super(httpStatus, reason, message);
+    }
+}

--- a/src/main/java/lems/cowshed/service/CustomUserDetails.java
+++ b/src/main/java/lems/cowshed/service/CustomUserDetails.java
@@ -45,7 +45,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole()));
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().toString()));
     }
 
     @Override

--- a/src/main/java/lems/cowshed/service/UserService.java
+++ b/src/main/java/lems/cowshed/service/UserService.java
@@ -1,15 +1,18 @@
 package lems.cowshed.service;
 
-import lems.cowshed.api.controller.UserUtils;
+import lems.cowshed.api.controller.SecurityContextUtil;
 import lems.cowshed.api.controller.dto.user.request.UserEditRequestDto;
+import lems.cowshed.api.controller.dto.user.request.UserLoginRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserSaveRequestDto;
 import lems.cowshed.api.controller.dto.user.response.UserEventResponseDto;
+import lems.cowshed.domain.user.Role;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
 import lems.cowshed.domain.user.query.UserEventQueryDto;
 import lems.cowshed.domain.user.query.UserQueryRepository;
-import lems.cowshed.exception.DuplicateUsernameException;
-import lems.cowshed.exception.UserNotFoundException;
+import lems.cowshed.exception.UserEditException;
+import lems.cowshed.exception.UserRegisterException;
+import lems.cowshed.exception.UserLoginException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -27,45 +32,60 @@ public class UserService {
     private final UserQueryRepository userQueryRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public void JoinProcess(UserSaveRequestDto joinDto) {
-        String email = joinDto.getEmail();
-        String username = joinDto.getUsername();
-        String password = joinDto.getPassword();
+    public void login(UserLoginRequestDto loginDto){
+         String email = loginDto.getEmail();
+         User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserLoginException(NOT_FOUND, email, email + " 유저를 찾을수 없습니다."));
 
-        if(userRepository.existsByEmailOrUsername(email, username)){
-            throw new UserNotFoundException("username or email already exists");
+        if(isPasswordValidationFail(loginDto, user)){
+            throw new UserLoginException(BAD_REQUEST, "password", "아이디와 비밀번호를 다시 확인 해주세요");
+        }
+    }
+
+    public void JoinProcess(UserSaveRequestDto saveDto) {
+        if(isExistDuplicateEmailOrUsername(saveDto)){
+            throwException(saveDto);
         }
 
-        User user = User.registerUser(username, bCryptPasswordEncoder.encode(password), email, "ROLE_USER");
+        final User user = saveDto.toEntityForRegister(bCryptPasswordEncoder, Role.ROLE_USER);
         userRepository.save(user);
     }
 
-    public void editProcess(UserEditRequestDto userEditRequestDto){
-        checkDuplicateName(userEditRequestDto.getUsername());
-        User user = getUserById();
+    public void editProcess(UserEditRequestDto editDto, Long userId){
+        userRepository.findByUsername(editDto.getUsername())
+                .ifPresent(u -> throwException(editDto));
 
-        user.modifyDetails(userEditRequestDto);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserEditException(NOT_FOUND, String.valueOf(userId), "해당하는 유저를 찾을수 없습니다."));
+
+        user.modifyContents(editDto);
     }
 
-    public UserEventResponseDto getUserEvent(LocalDate localDate){
-        List<UserEventQueryDto> userEventDto = userQueryRepository.findUserWithEvent(UserUtils.getUserId());
-        computeAge(userEventDto, localDate.getYear());
+    public UserEventResponseDto getUserEvent(LocalDate currentYear){
+        List<UserEventQueryDto> userEventDtoList = userQueryRepository.findUserWithEvent(SecurityContextUtil.getUserId());
+        computeAge(userEventDtoList, currentYear.getYear());
 
-        return new UserEventResponseDto(userEventDto);
+        return new UserEventResponseDto(userEventDtoList);
     }
 
-    private void checkDuplicateName(String username) {
-        userRepository.findByUsername(username).ifPresent(u -> {
-            throw new DuplicateUsernameException("duplicate user name exist");
-        });
+    private boolean isPasswordValidationFail(UserLoginRequestDto loginDto, User user) {
+        System.out.println(loginDto.getPassword() + "정보 " + user.getPassword());
+        return !bCryptPasswordEncoder.matches(loginDto.getPassword(), user.getPassword());
     }
 
-    private User getUserById() {
-        return userRepository.findById(UserUtils.getUserId()).orElseThrow(() -> new UserNotFoundException("user not found"));
+    private boolean isExistDuplicateEmailOrUsername(UserSaveRequestDto saveDto) {
+        return userRepository.existsByEmailOrUsername(saveDto.getEmail(), saveDto.getUsername());
+    }
+
+    private void throwException(UserSaveRequestDto saveDto) {
+        throw new UserRegisterException(BAD_REQUEST, "usernameOrEmail",saveDto.getEmail() + " " + saveDto.getUsername() + "은 이미 존재 하는 이름 혹은 이메일 입니다.");
+    }
+
+    private void throwException(UserEditRequestDto editDto) {
+        throw new UserEditException(BAD_REQUEST, "username", editDto.getUsername() + " 는 이미 존재 하는 닉네임 입니다.");
     }
 
     private void computeAge(List<UserEventQueryDto> userEventDto, int currentYear) {
         userEventDto.forEach(dto -> dto.setAge(currentYear - dto.getBirth().getYear() + 1));
     }
-
 }

--- a/src/test/java/lems/cowshed/api/controller/user/UserApiControllerTest.java
+++ b/src/test/java/lems/cowshed/api/controller/user/UserApiControllerTest.java
@@ -1,0 +1,122 @@
+package lems.cowshed.api.controller.user;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lems.cowshed.api.controller.dto.user.request.UserSaveRequestDto;
+import lems.cowshed.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WithMockUser
+@WebMvcTest(controllers = UserApiController.class)
+class UserApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("신규 회원이 회원 가입을 합니다.")
+    @Test
+    void saveUser() throws Exception {
+
+        //given
+        UserSaveRequestDto request = UserSaveRequestDto.builder()
+                .username("test")
+                .email("test@naver.com")
+                .password("tempPassword")
+                .build();
+
+        //when //then
+        mockMvc.perform(
+                post("/users/register")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("성공"));
+    }
+
+    @DisplayName("신규 회원이 회원 가입을 할 때 닉네임 값은 필수 입니다.")
+    @Test
+    void saveUserWithoutUsername() throws Exception {
+        //given
+        UserSaveRequestDto request = UserSaveRequestDto.builder()
+                .email("test@naver.com")
+                .password("tempPassword")
+                .build();
+
+        //when //then
+        mockMvc.perform(
+                        post("/users/register")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error[0].field").value("username"))
+                .andExpect(jsonPath("$.error[0].message").value("유저 닉네임은 필수 입니다."));
+    }
+
+    @DisplayName("신규 회원이 회원 가입을 할 때 이메일 값은 필수 입니다.")
+    @Test
+    void saveUserWithoutEmail() throws Exception {
+        //given
+        UserSaveRequestDto request = UserSaveRequestDto.builder()
+                .username("test")
+                .password("tempPassword")
+                .build();
+
+        //when //then
+        mockMvc.perform(
+                        post("/users/register")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error[0].field").value("email"))
+                .andExpect(jsonPath("$.error[0].message").value("이메일 값은 필수 입니다."));
+    }
+
+    @DisplayName("신규 회원이 회원 가입을 할 때 패스워드 값은 필수 입니다.")
+    @Test
+    void saveUserWithoutPassword() throws Exception {
+        //given
+        UserSaveRequestDto request = UserSaveRequestDto.builder()
+                .username("test")
+                .email("test@naver.com")
+                .build();
+
+        //when //then
+        mockMvc.perform(
+                        post("/users/register")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error[0].field").value("password"))
+                .andExpect(jsonPath("$.error[0].message").value("패스워드는 필수 입니다."));
+    }
+}

--- a/src/test/java/lems/cowshed/domain/user/CustomSecurityContextFactory.java
+++ b/src/test/java/lems/cowshed/domain/user/CustomSecurityContextFactory.java
@@ -18,7 +18,7 @@ public class CustomSecurityContextFactory implements WithSecurityContextFactory<
                 .id(annotation.id())
                 .username(annotation.username())
                 .password(annotation.password())
-                .role("ROLE_USER")
+                .role(Role.ROLE_USER)
                 .build();
 
         CustomUserDetails principal = new CustomUserDetails(user);

--- a/src/test/java/lems/cowshed/service/UserServiceTest.java
+++ b/src/test/java/lems/cowshed/service/UserServiceTest.java
@@ -1,83 +1,206 @@
 package lems.cowshed.service;
 
 import lems.cowshed.api.controller.dto.user.request.UserEditRequestDto;
+import lems.cowshed.api.controller.dto.user.request.UserLoginRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserSaveRequestDto;
+import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.user.Mbti;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
 import lems.cowshed.domain.user.WithMockCustomUser;
-import lems.cowshed.exception.UserNotFoundException;
+import lems.cowshed.domain.user.query.UserQueryRepository;
+import lems.cowshed.exception.UserEditException;
+import lems.cowshed.exception.UserLoginException;
+import lems.cowshed.exception.UserRegisterException;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@WithMockCustomUser(id = 1L)
 class UserServiceTest {
 
-    @Autowired UserService userService;
-    @Autowired UserRepository userRepository;
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserQueryRepository userQueryRepository;
 
     @DisplayName("신규 회원을 등록 한다.")
     @Test
     void JoinProcess() {
         //given
-        UserSaveRequestDto request = createSaveDto("test@naver.com", "테스트");
-        
+        String email = "test@naver.com";
+        UserSaveRequestDto request = createSaveDto(email, "테스트", "tempPassword");
+
         //when
         userService.JoinProcess(request);
 
         //then
-        User findUser = userRepository.findByUsername("테스트").orElseThrow();
+        User findUser = userRepository.findByEmail(email).orElseThrow();
         assertThat(findUser).isNotNull()
                 .extracting("username", "email")
                 .containsExactly("테스트", "test@naver.com");
     }
 
-    @DisplayName("신규 회원을 등록 할 때 이미 등록된 이름, 이메일이 있을 경우 예외가 발생 한다.")
-    @CsvSource(value = {"noreg@naver.com-등록", "reg@naver.com-비등록", "reg@naver.com-등록"}, delimiter = '-')
+    @DisplayName("신규 회원을 등록 할 때 이미 등록된 이름 혹은 이메일이 있을 경우 예외가 발생 한다.")
+    @CsvSource(value = {"PriorRegister@naver.com-비등록", "NonRegister@naver.com-사전등록", "PriorRegister@naver.com-사전등록"}, delimiter = '-')
     @ParameterizedTest
     void JoinProcessWhenDuplicateNameOrEmail(String email, String username) {
         //given
-        User user = createUser("reg@naver.com", "등록");
-        userRepository.save(user);
+        UserSaveRequestDto oldRequest = createSaveDto("PriorRegister@naver.com", "사전등록");
+        userService.JoinProcess(oldRequest);
 
         UserSaveRequestDto request = createSaveDto(email, username);
 
         //when //then
         assertThatThrownBy(() -> userService.JoinProcess(request))
-                .isInstanceOf(UserNotFoundException.class)
-                .hasMessage("username or email already exists");
+                .isInstanceOf(UserRegisterException.class)
+                .hasMessage(request.getEmail() + " " + request.getUsername() + "은 이미 존재 하는 이름 혹은 이메일 입니다.")
+                .extracting(e -> ((UserRegisterException) e).getHttpStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
-    @Disabled
-    @DisplayName("회원 정보를 수정 한다.")
+    @DisplayName("회원 가입을 한 유저가 로그인을 한다.")
     @Test
-    void editTest() {
+    void login() {
         //given
-        User user = createUser("test@naver.com", "테스트");
+        String email = "test@naver.com";
+        String validPassword = "validPassword";
+        UserSaveRequestDto saveRequest = createSaveDto(email, "테스트", validPassword);
+
+        userService.JoinProcess(saveRequest);
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        UserLoginRequestDto request = createLoginDto(email, validPassword);
+
+        //when //then
+        userService.login(request);
+    }
+
+    @DisplayName("회원이 로그인을 할때 등록 안된 이메일의 경우 예외가 발생한다.")
+    @Test
+    void loginWhenNotFoundUserByEmail() {
+        //given
+        UserLoginRequestDto request = createLoginDto("NonRegisterEmail@naver.com", "tempPassword");
+
+        //when //then
+        assertThatThrownBy(() -> userService.login(request))
+                .isInstanceOf(UserLoginException.class)
+                .hasMessage(request.getEmail() + " 유저를 찾을수 없습니다.")
+                .extracting(e -> ((UserLoginException) e).getHttpStatus())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @DisplayName("회원가입을 한 유저가 로그인 할때 비밀번호가 틀리면 예외가 발생한다.")
+    @Test
+    void loginWhenNotValidationPassword() {
+        //given
+        String email = "test@naver.com";
+        UserSaveRequestDto saveRequest = createSaveDto(email, "테스트", "validPassword");
+        userService.JoinProcess(saveRequest);
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        UserLoginRequestDto request = createLoginDto(user.getEmail(), "notValidPassword");
+
+        //when //then
+        assertThatThrownBy(() -> userService.login(request))
+                .isInstanceOf(UserLoginException.class)
+                .hasMessage("아이디와 비밀번호를 다시 확인 해주세요")
+                .extracting(e -> ((UserLoginException) e).getHttpStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("회원의 세부 정보를 수정 한다.")
+    @Test
+    void editProcess() {
+        //given
+        User user = createUser("테스트", "test@naver.com");
         userRepository.save(user);
 
-        LocalDate birth = LocalDate.of(1999, 3, 20);
+        String editName = "수정한닉네임";
+        UserEditRequestDto request = createEditDto(editName, "안녕하세요!", Mbti.INTP);
+
+        //when
+        userService.editProcess(request, user.getId());
+
+        //then
+        User findUser = userRepository.findByUsername(editName).orElseThrow();
+        assertThat(findUser).extracting("username", "introduction", "mbti")
+                .containsExactly(editName, "안녕하세요!", Mbti.INTP);
+    }
+
+    @DisplayName("회원의 세부 정보를 수정 할때 같은 닉네임을 가진 사람이 있다면 예외가 발생 한다.")
+    @Test
+    void editProcessWhenDuplicateUsername() {
+        //given
+        String duplicateName = "테스트";
+        User priorRegisterUser = createUser(duplicateName, "test@naver.com");
+        userRepository.save(priorRegisterUser);
+
+        User user = createUser("신규", "new@naver.com");
+        userRepository.save(user);
+
+        UserEditRequestDto request = createEditDto(duplicateName, "안녕하세요!", Mbti.INTP);
+
+        //when //then
+        assertThatThrownBy(() -> userService.editProcess(request, user.getId()))
+                .isInstanceOf(UserEditException.class)
+                .hasMessage(request.getUsername() + " 는 이미 존재 하는 닉네임 입니다.")
+                .extracting(e -> ((UserEditException) e).getHttpStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("회원의 세부 정보를 수정 할때 조회할 유저의 식별자 값이 저장소에 없다면 예외가 발생 한다")
+    @Test
+    void editProcessWhenNotFoundUserById() {
+        //given
+        User user = createUser("test", "test@naver.com");
+        userRepository.save(user);
+
+        UserEditRequestDto request = createEditDto("새닉네임", "안녕하세요!", Mbti.INTP);
+
+        //when //then
+        assertThatThrownBy(() -> userService.editProcess(request, 2L))
+                .isInstanceOf(UserEditException.class)
+                .hasMessage("해당하는 유저를 찾을수 없습니다.")
+                .extracting(e -> ((UserEditException) e).getHttpStatus())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    //TODO
+    @DisplayName("회원이 참여 중인 소모임을 조회 한다.")
+    @Test
+    @Disabled
+    void test() {
+        //given
 
         //when
 
         //then
     }
 
-    private User createUser(String email, String username) {
+    private User createUser(String username, String email) {
         return User.builder()
                 .username(username)
                 .email(email)
+                .build();
+    }
+
+    private UserSaveRequestDto createSaveDto(String email, String username, String password) {
+        return UserSaveRequestDto.builder()
+                .email(email)
+                .username(username)
+                .password(password)
                 .build();
     }
 
@@ -86,6 +209,23 @@ class UserServiceTest {
                 .email(email)
                 .username(username)
                 .password("tempPassword")
+                .build();
+    }
+
+    private UserLoginRequestDto createLoginDto(String email, String password){
+        return UserLoginRequestDto.builder()
+                .email(email)
+                .password(password)
+                .build();
+    }
+
+    private UserEditRequestDto createEditDto(String username, String introduction, Mbti mbti) {
+        return UserEditRequestDto.builder()
+                .username(username)
+                .introduction(introduction)
+                .localName("대구광역시 수성구")
+                .birth(LocalDate.of(2024, 11, 20))
+                .character(mbti)
                 .build();
     }
 }


### PR DESCRIPTION
##
### 🌱 작업 내용
### Role enum 타입 도입
타입 안정성을 위해 권한을 String -> enum으로 교체 했습니다.

![image](https://github.com/user-attachments/assets/80f69f80-98b2-4012-82ce-ca79206e5ecf)

연관된 설정 파일이 부분적으로 수정 되었습니다.
##
### 🌱 회원 가입 코드 수정
<strong>Before </strong>
<pre>
 User user = User.registerUser(username, bCryptPasswordEncoder.encode(password), email, "ROLE_USER");
</pre>
<strong> After </strong>
<pre>
User user = saveDto.toEntityForRegister(bCryptPasswordEncoder, Role.ROLE_USER);

public User toEntityForRegister(BCryptPasswordEncoder bCryptPasswordEncoder, Role role){
        return User.builder()
                .username(username)
                .password(bCryptPasswordEncoder.encode(password))
                .email(email)
                .role(role)
                .build();
    }
</pre>

- registerUser : String 파라미터가 여러개 이므로 파라미터 바인딩 실수 가능성 있습니다.
- saveDto가 User를 생성 하도록 하고 Builder 패턴을 통해 바인딩 실수를 줄였습니다.
- User에게 saveDto를 받아 생성 해도 되지만 User는 saveDto를 알지 못하는게 좋다고 생각 했습니다.
##
### 🌱 로그인 기능 추가
<pre>
public void login(UserLoginRequestDto loginDto){
         String email = loginDto.getEmail();
         User user = userRepository.findByEmail(email)
                .orElseThrow(() -> new UserLoginException(NOT_FOUND, email, email + " 유저를 찾을수 없습니다."));

        if(isPasswordValidationFail(loginDto, user)){
            throw new UserLoginException(BAD_REQUEST, "password", "아이디와 비밀번호를 다시 확인 해주세요");
        }
    }
</pre>
##
### 🌱 비지니스 레이어 테스트 문제
<pre>
public void editProcess(UserEditRequestDto userEditRequestDto){
        User user = getUserById();
        (...생략)
    }

 private User getUserById() {
        return userRepository.findById(UserUtils.getUserId()).orElseThrow(() -> new UserNotFoundException("user not found"));
    }
</pre>
UserUtils.getUserId() : 시큐리티 컨텍스트 홀더에 있는 User.id 값 사용 했습니다.
그러므로 서비스 코드가 컨텍스트 홀더에 의존적 입니다.
<pre>
@SpringBootTest
@Transactional
@WithMockCustomUser(id = 1L)
class UserServiceTest {
</pre>
테스트 코드 또한 의존적이므로 불편함이 생겼습니다.
ex) 2명 유저를 찾을려면 컨텍스트 홀더 값을 바꿔야 하는 문제가 발생 했습니다.
### 🔨 해결 방법 
의존성을 컨트롤러로 이동 시키고 파라미터 값으로 받도록 해결 했습니다.
<pre>
controller
userService.editProcess(userEditRequestDto, userId);

service
 public void editProcess(UserEditRequestDto editDto, Long userId){
</pre>
##
### 🌱 비지니스 레이어 예외 추가
<pre>
public class BusinessException extends IllegalArgumentException{

    private final HttpStatus httpStatus;
    private final String reason;
    ...(생략)
}
</pre>
- 상태코드를 알기 위한 httpStatus 원인 reason
- BusinessException를 상속 받는 Exception 생성 ( 공통 예외 처리에서 BusinessException로 처리 하기 위해 )
- 이름으로 어디서 발생한 예외 인지 알기 위해 UserLoginException, UserRegisterException.. 생성
##
### 🌱 비지니스 레이어 테스트 결과
![image](https://github.com/user-attachments/assets/75188eee-8aa0-4b95-83d8-d5b3e6b99b2e)
- 정상 동작 / 예외 상황 체크

##
### ⏰ 기타 사항
- git ignore 추가
