### PR TITLE
실행 테스트시 발생 문제 리팩토링

### DIFF
--- a/src/main/java/lems/cowshed/api/advice/GeneralAdvice.java
+++ b/src/main/java/lems/cowshed/api/advice/GeneralAdvice.java
@@ -43,7 +43,7 @@ public class GeneralAdvice {
     //TODO 데이터 == null 이면
     @ExceptionHandler(value = {Exception.class})
     public ErrorResponse<String> handleExceptionFromAPIMethod(Exception ex){
-        return ErrorResponse.of(ErrorCode.INTERNAL_ERROR, "");
+        return ErrorResponse.of(ErrorCode.INTERNAL_ERROR, ex.getMessage());
     }
 
     @Getter

--- a/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
@@ -53,13 +53,14 @@ public class EventSaveRequestDto {
         this.content = content;
     }
 
-    public Event toEntity() {
+    public Event toEntity(String username) {
         return Event.builder()
                 .name(this.name)
                 .category(this.category)
                 .location(this.location)
                 .eventDate(this.eventDate)
                 .capacity(this.getCapacity())
+                .author(username)
                 .content(this.content)
                 .build();
     }

--- a/src/main/java/lems/cowshed/api/controller/dto/event/request/EventUpdateRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/request/EventUpdateRequestDto.java
@@ -22,7 +22,6 @@ public class EventUpdateRequestDto {
     @Schema(description = "모임 이름", example = "새벽 한강 러닝 모임")
     String name;
 
-    @NotBlank
     @Schema(description = "카테고리", example = "스포츠")
     Category category;
 

--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -29,8 +29,9 @@ public class EventController implements EventSpecification {
     }
 
     @PostMapping
-    public CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto) {
-        eventService.saveEvent(requestDto);
+    public CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto,
+                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        eventService.saveEvent(requestDto, customUserDetails.getUsername());
         return CommonResponse.success();
     }
 

--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -42,7 +42,7 @@ public class EventController implements EventSpecification {
     }
 
     @PostMapping("/{event-id}/join")
-    public CommonResponse<Void> saveUserEvent(@PathVariable Long eventId,
+    public CommonResponse<Void> saveUserEvent(@PathVariable("event-id") Long eventId,
                                               @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         eventService.joinEvent(eventId, customUserDetails.getUserId());
         return CommonResponse.success();

--- a/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
@@ -26,9 +26,11 @@ public interface EventSpecification {
     @Operation(summary = "모임 목록 페이징 조회", description = "모임을 페이징 조회 합니다.")
     @ApiErrorCodeExamples(ErrorCode.NOT_FOUND_ERROR)
     CommonResponse<Slice<EventPreviewResponseDto>> getPagingEvents(Pageable pageable);
+
     @Operation(summary = "모임 등록", description = "모임을 등록 합니다.")
     @ApiErrorCodeExamples({ErrorCode.SUCCESS, ErrorCode.NOT_FOUND_ERROR})
-    CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto);
+    CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto,
+                                   @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
     @Operation(summary = "모임 상세 조회", description = "모임의 상세 정보를 반환 합니다.")
     @ApiErrorCodeExample(ErrorCode.NOT_FOUND_ERROR)

--- a/src/main/java/lems/cowshed/domain/event/Event.java
+++ b/src/main/java/lems/cowshed/domain/event/Event.java
@@ -23,6 +23,7 @@ public class Event extends BaseEntity {
     @Column(name = "event_date")
     private LocalDateTime eventDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "category")
     private Category category;
 

--- a/src/main/java/lems/cowshed/domain/user/query/UserEventQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/user/query/UserEventQueryDto.java
@@ -23,7 +23,7 @@ public class UserEventQueryDto {
     private Mbti mbti;
 
     @Schema(description = "나이", example = "26")
-    private int age;
+    private Integer age;
 
     @JsonIgnore
     @Schema(description = "생일", example = "2020-01-01")

--- a/src/main/java/lems/cowshed/service/EventService.java
+++ b/src/main/java/lems/cowshed/service/EventService.java
@@ -35,8 +35,8 @@ public class EventService {
         return slice.map(EventPreviewResponseDto::new);
     }
 
-    public void saveEvent(EventSaveRequestDto requestDto) {
-        Event event = requestDto.toEntity();
+    public void saveEvent(EventSaveRequestDto requestDto, String username) {
+        Event event = requestDto.toEntity(username);
         eventRepository.save(event);
     }
 

--- a/src/main/java/lems/cowshed/service/UserService.java
+++ b/src/main/java/lems/cowshed/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
 
     public UserEventResponseDto findUserParticipatingInEvent(LocalDate currentYear, Long userId){
         List<UserEventQueryDto> userEventDtoList = userQueryRepository.findUserParticipatingInEvent(userId);
-        userEventDtoList.forEach(dto -> dto.setAge((int) ChronoUnit.YEARS.between(dto.getBirth(), currentYear) + 1));
+        calculateAndSetDtoAge(currentYear, userEventDtoList);
 
         return new UserEventResponseDto(userEventDtoList);
     }
@@ -71,6 +71,17 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
 
         user.modifyContents(editDto);
+    }
+
+    private void calculateAndSetDtoAge(LocalDate currentYear, List<UserEventQueryDto> userEventDtoList) {
+        userEventDtoList.forEach((UserEventQueryDto dto) -> {
+            if (dto.getBirth() == null){
+                dto.setAge(null);
+            }
+            else {
+                dto.setAge((int) ChronoUnit.YEARS.between(dto.getBirth(), currentYear) + 1);
+            }
+        });
     }
 
     private boolean isPasswordValidationFail(UserLoginRequestDto loginDto, User user) {

--- a/src/test/java/lems/cowshed/service/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/EventServiceTest.java
@@ -68,7 +68,7 @@ class EventServiceTest {
         EventSaveRequestDto request = createRequestDto("자전거 모임", "서울", 10);
 
         //when
-        eventService.saveEvent(request);
+        eventService.saveEvent(request, "테스터");
 
         //then
         Event findEvent = eventRepository.findByName("자전거 모임");


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 문제 1. 모임 등록 시 등록자 저장 안되어 있는 문제 ]
- 저장시 시큐리티 컨텍스트 홀더에 있는 유저 이름으로 저장

[ 추후 유저 수정 ]
- 만약 회원 이름을 수정한다면? 모임 등록자 이름이 바뀐다.
- 모임 등록자 이름 업데이트 쿼리 필요

[ 문제 2. 모임 Category 저장 타입 누락 ] 
- @Enumerated(EnumType.STRING) 등록

[ 문제 3. 모임에 참여한 회원 조회 시 나이를 계산 할때 문제 ]
- 회원은 초기에 생년월일 (Birth) 입력 하지 않아도 되기 때문에 null이 들어갈 수 있다.
- 생년월일이 null 인경우 null 나이를 계산하고 나이 필드를 Integer로 변경
