### PR TITLE
모임 참여 동시성 문제 비관적 락 적용

### DIFF
--- a/src/main/java/lems/cowshed/domain/event/Event.java
+++ b/src/main/java/lems/cowshed/domain/event/Event.java
@@ -6,7 +6,6 @@ import lems.cowshed.domain.BaseEntity;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -87,6 +86,10 @@ public class Event extends BaseEntity {
         if(requestDto.getCategory() != null) this.category = requestDto.getCategory();
         if(requestDto.getEventDate() != null) this.eventDate = requestDto.getEventDate();
         if(requestDto.getLocation() != null) this.location = requestDto.getLocation();
+    }
+
+    public boolean isNotParticipate(long participateCount){
+        return capacity == participateCount;
     }
 }
 

--- a/src/main/java/lems/cowshed/domain/event/EventRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/EventRepository.java
@@ -1,15 +1,18 @@
 package lems.cowshed.domain.event;
 
-import lems.cowshed.api.controller.dto.event.request.EventSaveRequestDto;
-import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
-import org.springframework.data.domain.PageRequest;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
-import java.util.List;
+import java.util.Optional;
+
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Event> findPessimisticLockById(Long eventId);
     Slice<Event> findSliceBy(Pageable pageable);
     Event findByName(String name);
 }

--- a/src/main/java/lems/cowshed/domain/userevent/UserEventRepository.java
+++ b/src/main/java/lems/cowshed/domain/userevent/UserEventRepository.java
@@ -1,6 +1,13 @@
 package lems.cowshed.domain.userevent;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserEventRepository extends JpaRepository<UserEvent, Long> {
+
+    @Query("SELECT COUNT(ue) From UserEvent ue Where ue.event.id = :eventId")
+    long countParticipantByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/lems/cowshed/exception/Message.java
+++ b/src/main/java/lems/cowshed/exception/Message.java
@@ -15,7 +15,8 @@ public enum Message {
     BOOKMARK_NOT_FOUND("북마크를 찾지 못했습니다."),
 
     EVENT_NOT_FOUND("모임을 찾지 못했습니다."),
-    EVENT_NOT_REGISTERED_BY_USER("회원이 등록한 모임이 아닙니다.");
+    EVENT_NOT_REGISTERED_BY_USER("회원이 등록한 모임이 아닙니다."),
+    EVENT_CAPACITY_OVER("참여 가능한 회원 수를 초과 하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/lems/cowshed/exception/Reason.java
+++ b/src/main/java/lems/cowshed/exception/Reason.java
@@ -15,7 +15,7 @@ public enum Reason {
     BOOKMARK_ID("boomark_id"),
 
     EVENT_ID("event_id"),
-
+    EVENT_CAPACITY("event_capacity"),
     BusinessReason("Business");
     private final String text;
 }

--- a/src/main/java/lems/cowshed/service/EventService.java
+++ b/src/main/java/lems/cowshed/service/EventService.java
@@ -53,8 +53,12 @@ public class EventService {
     }
 
     public long joinEvent(Long eventId, Long userId) {
-        Event event = eventRepository.findById(eventId).orElseThrow(
+        Event event = eventRepository.findPessimisticLockById(eventId).orElseThrow(
                 () -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));
+
+        if(isNotPossibleToParticipate(event)){
+            throw new BusinessException(EVENT_CAPACITY, EVENT_CAPACITY_OVER);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
@@ -90,5 +94,9 @@ public class EventService {
 
     private boolean notRegisteredEventByUser(String userName, Event event) {
         return !event.getAuthor().equals(userName);
+    }
+
+    private boolean isNotPossibleToParticipate(Event event) {
+        return event.isNotParticipate(userEventRepository.countParticipantByEventId(event.getId()));
     }
 }

--- a/src/test/java/lems/cowshed/domain/event/EventRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/EventRepositoryTest.java
@@ -1,6 +1,9 @@
 package lems.cowshed.domain.event;
 
 import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
+import lems.cowshed.domain.user.UserRepository;
+import lems.cowshed.domain.userevent.UserEventRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,19 @@ class EventRepositoryTest {
 
     @Autowired
     EventRepository eventRepository;
+
+    @Autowired
+    UserEventRepository userEventRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void cleanUp(){
+        userEventRepository.deleteAllInBatch();
+        eventRepository.deleteAllInBatch();
+        userEventRepository.deleteAllInBatch();
+    }
 
     @DisplayName("모임을 요청 받은 페이지의 사이즈 만큼 조회 한다.")
     @Test


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 모임 동시 참여에 대한 낙관적 락 적용 실패 ]
![image](https://github.com/user-attachments/assets/0d4618b2-ef9a-423f-aec3-092fed4d358b)

### [ 낙관적 락 ]
- 락을 걸지 않고 어플리케이션에서 해결 하는 방법
- 두번의 갱신 분실 문제에 대해서 첫번째 수정만을 인정 합니다.

##
### [ 실패 이유 : 데드락 발생 ]  

![image](https://github.com/user-attachments/assets/66796228-8389-4981-b80a-e496d8c20351)  

- 모임 참여 테이블 :  회원 id ( fk ), 모임 id ( fk )
- Mysql 외래키 존재 테이블 :  수정, 삽입, 삭제 경우 부모 테이블에 값이 존재 하는지 S-Lock 걸고 확인 합니다.
- 멀티 스레드의 트랜잭션에서 모임에 대한 S-Lock을 획득 합니다. ( 공유 가능 )
- 데이터를 삽입 하기 위해 모임의 X-Lock을 획득 시도 / 다른 트랜잭션의 S-Lock 으로 인해 데드락이 발생 합니다.

##
### [ 비관적 락 적용 ]
- 데이터베이스의 락을 활용 하여 동시성 문제를 해결 하는 방법
- 충돌이 발생할 것을 예상 하고 트랜잭션이 데이터를 읽거나 수정할 때 다른 트랜잭션의 접근을 방지  

![image](https://github.com/user-attachments/assets/55cf5bb6-53be-4f11-aace-dba0c0ca926b)
