### PR TITLE
Enum 타입 Json parse 에러 수정

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/Enum.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/Enum.java
@@ -1,0 +1,18 @@
+package lems.cowshed.api.controller.dto;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {EnumValidator.class})
+public @interface Enum {
+    String message() default "Invalid Enum Type";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/lems/cowshed/api/controller/dto/EnumValidator.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/EnumValidator.java
@@ -1,0 +1,21 @@
+package lems.cowshed.api.controller.dto;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+
+@Slf4j
+public class EnumValidator implements ConstraintValidator<Enum, java.lang.Enum> {
+
+    @Override
+    public boolean isValid(java.lang.Enum value, ConstraintValidatorContext context) {
+        if(value == null){
+            return false;
+        }
+
+        Class<?> declaringClass = value.getDeclaringClass();
+        return Arrays.asList(declaringClass.getEnumConstants()).contains(value);
+    }
+}

--- a/src/main/java/lems/cowshed/api/controller/dto/user/request/UserSaveRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/request/UserSaveRequestDto.java
@@ -2,6 +2,8 @@ package lems.cowshed.api.controller.dto.user.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lems.cowshed.api.controller.dto.Enum;
 import lems.cowshed.domain.user.Gender;
 import lems.cowshed.domain.user.Role;
 import lems.cowshed.domain.user.User;
@@ -25,6 +27,7 @@ public class UserSaveRequestDto {
     private String password;
 
     @Schema(description = "성별", example = "MALE")
+    @Enum(message = "성별은 `MALE`, `FEMALE`을 허용 합니다.")
     private Gender gender;
 
     @Builder
@@ -44,4 +47,5 @@ public class UserSaveRequestDto {
                 .role(role)
                 .build();
     }
+
 }

--- a/src/main/java/lems/cowshed/domain/event/Category.java
+++ b/src/main/java/lems/cowshed/domain/event/Category.java
@@ -1,5 +1,17 @@
 package lems.cowshed.domain.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum Category {
     SPORTS, TRAVEL, READING, MUSIC, PICTURE, FOOD, FASHION, BEAUTY;
+
+    @JsonCreator
+    public static Category getEnumFromValue(String value){
+        for (Category category : Category.values()) {
+            if(category.name().equals(value)){
+                return category;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/lems/cowshed/domain/user/Gender.java
+++ b/src/main/java/lems/cowshed/domain/user/Gender.java
@@ -1,5 +1,17 @@
 package lems.cowshed.domain.user;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum Gender {
     FEMALE, MALE;
+
+    @JsonCreator
+    public static Gender getEnumFromValue(String value){
+        for (Gender gender : Gender.values()) {
+            if(gender.name().equals(value)){
+                return gender;
+            }
+        }
+        return null;
+    }
 }

--- a/src/test/java/lems/cowshed/api/controller/user/UserApiControllerTest.java
+++ b/src/test/java/lems/cowshed/api/controller/user/UserApiControllerTest.java
@@ -1,8 +1,10 @@
 package lems.cowshed.api.controller.user;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lems.cowshed.api.controller.dto.user.request.UserLoginRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserSaveRequestDto;
+import lems.cowshed.domain.user.Gender;
 import lems.cowshed.service.BookmarkService;
 import lems.cowshed.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import static lems.cowshed.domain.user.Gender.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -44,6 +47,7 @@ class UserApiControllerTest {
                 .username("test")
                 .email("test@naver.com")
                 .password("tempPassword")
+                .gender(MALE)
                 .build();
 
         //when //then
@@ -64,6 +68,7 @@ class UserApiControllerTest {
         UserSaveRequestDto request = UserSaveRequestDto.builder()
                 .email("test@naver.com")
                 .password("tempPassword")
+                .gender(MALE)
                 .build();
 
         //when //then
@@ -86,6 +91,7 @@ class UserApiControllerTest {
         UserSaveRequestDto request = UserSaveRequestDto.builder()
                 .username("test")
                 .password("tempPassword")
+                .gender(MALE)
                 .build();
 
         //when //then
@@ -107,6 +113,7 @@ class UserApiControllerTest {
         UserSaveRequestDto request = UserSaveRequestDto.builder()
                 .username("test")
                 .email("test@naver.com")
+                .gender(MALE)
                 .build();
 
         //when //then
@@ -119,6 +126,27 @@ class UserApiControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors[0].field").value("password"))
                 .andExpect(jsonPath("$.errors[0].message").value("패스워드는 필수 입니다."));
+    }
+
+    @DisplayName("신규 회원이 회원 가입을 할 때 성별 값은 필수 입니다.")
+    @Test
+    void saveUserWithoutGender() throws Exception {
+        //given
+        UserSaveRequestDto request = UserSaveRequestDto.builder()
+                .username("test")
+                .email("test@naver.com")
+                .build();
+
+        //when //then
+        mockMvc.perform(
+                post("/users/signUp")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+        )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0].field").value("gender"))
+                .andExpect(jsonPath("$.errors[0].message").value("성별은 필수 입니다."));
     }
 
     @DisplayName("회원이 로그인 할 때 이메일 값은 빈값일 수 없습니다.")


### PR DESCRIPTION
##
### 🌱 작업 내용
[ Enum 타입의 Json parse Error 수정 ]
<pre>
{
    "httpStatus": "INTERNAL_SERVER_ERROR",
    "code": 500,
    "message": "서버에 오류가 발생 했습니다.",
    "errors": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"signUp\""
}
</pre>
- Enum Type 바인딩 예외시 스프링 예외가 아닌 예외 원인과 메시지를 출력 하도록 변경
- 

##
### 🔎스크린 샷
[작업 결과 사진이 있다면 이해 하기 쉬울 것 같아요!]


##
### 📚 Reference
[참고 하신 내용을 작성해 주세요!]

##
### ⏰ 기타 사항
[기타사항을 입력해 주세요!]
