### PR TITLE
모임 조회 참석 여부 추가 / 조회 쿼리 개선

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/event/response/EventDetailResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/response/EventDetailResponseDto.java
@@ -1,14 +1,17 @@
 package lems.cowshed.api.controller.dto.event.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lems.cowshed.domain.event.Category;
-import lems.cowshed.domain.event.Event;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
 
 @Getter
 @Schema(description = "모임 상세")
@@ -40,6 +43,26 @@ public class EventDetailResponseDto {
     @Schema(description = "내가 참여한 모임 인지 여부", example = "YES")
     boolean isParticipated;
 
+    @JsonIgnore
+    String userList;
+
+    @QueryProjection
+    public EventDetailResponseDto(Long eventId, String name, String author, Category category,
+                                  LocalDateTime createdDate, String location, String content,
+                                  LocalDate eventDate, int capacity, long applicants, String userList) {
+        this.eventId = eventId;
+        this.name = name;
+        this.author = author;
+        this.category = category;
+        this.createdDate = createdDate;
+        this.location = location;
+        this.content = content;
+        this.eventDate = eventDate;
+        this.capacity = capacity;
+        this.applicants = applicants;
+        this.userList = userList;
+    }
+
     @Builder
     private EventDetailResponseDto(Long eventId, String author, String name, Category category,
                                   LocalDateTime createdDate, String location,
@@ -60,22 +83,26 @@ public class EventDetailResponseDto {
         this.isParticipated = isParticipated;
     }
 
-    public static EventDetailResponseDto from(Event event, long participantsCount, BookmarkStatus bookmarkStatus,
-                                              boolean registeredByMe, boolean isParticipated){
-        return EventDetailResponseDto.builder()
-                .eventId(event.getId())
-                .name(event.getName())
-                .author(event.getAuthor())
-                .category(event.getCategory())
-                .createdDate(event.getCreatedDateTime())
-                .location(event.getLocation())
-                .content(event.getContent())
-                .eventDate(event.getEventDate())
-                .capacity(event.getCapacity())
-                .applicants(participantsCount)
-                .bookmarkStatus(bookmarkStatus)
-                .registeredByMe(registeredByMe)
-                .isParticipated(isParticipated)
-                .build();
+    public void setParticipatedAndRegisteredByMeAndBookmarked(Long userId, String username, BookmarkStatus bookmarkStatus){
+        isParticipated(userId);
+        isRegisteredByMe(username);
+        isBookmarked(bookmarkStatus);
+    }
+
+    private void isParticipated(Long userId) {
+        isParticipated = Optional.ofNullable(userList)
+                .filter(s -> !s.isEmpty())
+                .map(s -> Arrays.stream(userList.split(","))
+                        .map(Long::parseLong)
+                        .anyMatch(id -> id.equals(userId)))
+                .orElse(false);
+    }
+
+    private void isRegisteredByMe(String username){
+        registeredByMe = username.equals(author);
+    }
+
+    private void isBookmarked(BookmarkStatus bookmarkStatus){
+        this.bookmarkStatus = bookmarkStatus;
     }
 }

--- a/src/main/java/lems/cowshed/domain/bookmark/Bookmark.java
+++ b/src/main/java/lems/cowshed/domain/bookmark/Bookmark.java
@@ -21,11 +21,11 @@ public class Bookmark extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/lems/cowshed/domain/event/EventRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/EventRepository.java
@@ -23,6 +23,4 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findByIdAndAuthor(Long eventId, String author);
     @Query("SELECT b.event.id FROM Bookmark b WHERE b.user.id = :userId AND b.event.id IN :eventIds AND b.status = :bookmarkStatus")
     Set<Long> findBookmarkedEventIds(@Param("userId") Long userId, @Param("eventIds") List<Long> eventIds, @Param("bookmarkStatus") BookmarkStatus bookmarkStatus);
-    @Query("select e from Event e Join Bookmark b on b.user.id = :userId And b.event.id = :eventId And b.status = :bookmarkStatus")
-    Optional<Event> findBookmarkedEvent(@Param("userId") Long userId, @Param("eventId") Long eventId, @Param("bookmarkStatus") BookmarkStatus bookmarkStatus);
 }

--- a/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
@@ -1,0 +1,45 @@
+package lems.cowshed.domain.event.query;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lems.cowshed.api.controller.dto.event.response.EventDetailResponseDto;
+import lems.cowshed.api.controller.dto.event.response.QEventDetailResponseDto;
+import org.springframework.stereotype.Repository;
+
+import static lems.cowshed.domain.event.QEvent.*;
+import static lems.cowshed.domain.userevent.QUserEvent.*;
+
+@Repository
+public class EventQueryRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public EventQueryRepository(EntityManager em, JPAQueryFactory queryFactory) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public EventDetailResponseDto getEventWithParticipated(Long eventId){
+        return queryFactory
+                .select(new QEventDetailResponseDto(
+                        event.id,
+                        event.name,
+                        event.author,
+                        event.category,
+                        event.createdDateTime,
+                        event.location,
+                        event.content,
+                        event.eventDate,
+                        event.capacity,
+                        userEvent.event.id.count(),
+                        Expressions.stringTemplate("GROUP_CONCAT({0})", userEvent.user.id)
+                )).from(userEvent)
+                .rightJoin(userEvent.event, event)
+                .on(userEvent.event.id.eq(event.id))
+                .where(event.id.eq(eventId))
+                .groupBy(event.id)
+                .fetchOne();
+    }
+}

--- a/src/main/java/lems/cowshed/domain/userevent/UserEventRepository.java
+++ b/src/main/java/lems/cowshed/domain/userevent/UserEventRepository.java
@@ -1,6 +1,5 @@
 package lems.cowshed.domain.userevent;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,8 +12,6 @@ public interface UserEventRepository extends JpaRepository<UserEvent, Long> {
     @Query("SELECT COUNT(ue) From UserEvent ue Where ue.event.id = :eventId")
     long countParticipantByEventId(@Param("eventId") Long eventId);
 
-    @EntityGraph(attributePaths = {"user"})
-    List<UserEvent> findFetchUserByEventId (Long eventId);
     List<UserEvent> findByEventIdIn (List<Long> eventIds);
     Optional<UserEvent> findByEventIdAndUserId (Long EventId, Long userId);
 }

--- a/src/test/java/lems/cowshed/service/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/EventServiceTest.java
@@ -171,7 +171,7 @@ class EventServiceTest {
                 .containsExactly("자전거 모임", "테스터", NOT_BOOKMARK, false);
     }
 
-    @DisplayName("모임을 조회할때 회원이 참여한 모임, 북마크한 모임은 표시가 되어있다.")
+    @DisplayName("모임을 조회할때 회원이 참여한 모임은 참여 상태로 되어있다.")
     @Test
     void getEventWhenParticipatedEvent() {
         //given
@@ -184,15 +184,12 @@ class EventServiceTest {
         UserEvent userEvent = UserEvent.of(user, event);
         userEventRepository.save(userEvent);
 
-        Bookmark bookmark = Bookmark.create(event, user, BOOKMARK);
-        bookmarkRepository.save(bookmark);
-
         //when
         EventDetailResponseDto response = eventService.getEvent(event.getId(), user.getId(), user.getUsername());
 
         //then
         assertThat(response).extracting("bookmarkStatus", "isParticipated")
-                .containsExactly(BOOKMARK, true);
+                .containsExactly(NOT_BOOKMARK, true);
     }
 
     @Transactional
@@ -214,8 +211,8 @@ class EventServiceTest {
 
         //then
         assertThat(result).isNotNull()
-                .extracting("bookmarkStatus")
-                .isEqualTo(BOOKMARK);
+                .extracting("bookmarkStatus", "isParticipated")
+                .containsExactly(BOOKMARK, false);
     }
 
     @Transactional


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 추가 요구사항 ]
- 모임 조회시 모임에 참석했는지 여부 추가

[ 모임 조회 요구 사항 ]
- 모임의 정보가 필요하다.
- 모임에 참여한 인원수, 북마크 여부, 회원(자신)의 참석 여부가 필요하다.

##
### 🌱 [ 기본 방식과 추가 사항 적용 ]
- 모임의 정보를 찾는다. ( 쿼리 1회 )
- 모임 테이블과 모임 참여 테이블을 조인 하여 참여 인원수를 찾는다. ( 쿼리 2회 )
- 북마크 테이블에 회원이 해당 모임에 상태가 BOOKMARK인 북마크를 찾는다. ( 쿼리 3회 )  

[ 추가 사항 적용 ] 
- 모임 참여 인원수 결과를 통해 자신(userId) 참여 여부를 찾는다.

![모임 조회 쿼리 개선](https://github.com/user-attachments/assets/4cddeba5-fa6d-46ef-839a-5d87e722ec37)

##
### 🌱 [ 개선 방식 ]
- 모임 테이블과 모임 참여 테이블을 조인 하여 모임 정보, 참여 인원수, 참여한 회원 userIds를 얻는다. ( 쿼리 1회 )
- 회원의 모임 참여 여부를 userIds를 통해 얻는다.
- 북마크 테이블에 회원이 해당 모임에 상태가 BOOKMARK인 북마크를 찾는다. ( 쿼리 2회 )

