### PR TITLE
Query Dto 이름 변경

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/bookmark/response/BookmarkResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/bookmark/response/BookmarkResponseDto.java
@@ -2,7 +2,6 @@ package lems.cowshed.api.controller.dto.bookmark.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
-import lems.cowshed.domain.user.query.UserBookmarkMyPageQueryDto;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/UserEventResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/UserEventResponseDto.java
@@ -1,7 +1,7 @@
 package lems.cowshed.api.controller.dto.user.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.domain.user.query.UserEventQueryDto;
+import lems.cowshed.domain.user.query.EventParticipantQueryDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -12,5 +12,5 @@ import java.util.List;
 @AllArgsConstructor
 public class UserEventResponseDto {
 
-    private List<UserEventQueryDto> userList;
+    private List<EventParticipantQueryDto> userList;
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
@@ -1,10 +1,9 @@
 package lems.cowshed.api.controller.dto.user.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
-import lems.cowshed.domain.user.query.UserBookmarkMyPageQueryDto;
-import lems.cowshed.domain.user.query.UserEventMyPageQueryDto;
-import lems.cowshed.domain.user.query.UserMyPageQueryDto;
+import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
+import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
+import lems.cowshed.domain.user.query.MyPageUserQueryDto;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,15 +16,15 @@ import java.util.List;
 public class UserMyPageResponseDto {
 
     @Schema(description = "유저 정보")
-    private UserMyPageQueryDto userDto;
+    private MyPageUserQueryDto userDto;
 
     @Schema(description = "참여 모임")
-    private List<UserEventMyPageQueryDto> userEventList;
+    private List<MyPageParticipatingEventQueryDto> userEventList;
 
     @Schema(description = "북마크 모임")
-    private List<UserBookmarkMyPageQueryDto> bookmarkList;
+    private List<MyPageBookmarkedEventQueryDto> bookmarkList;
 
-    public UserMyPageResponseDto(UserMyPageQueryDto userDto, List<UserEventMyPageQueryDto> userEventList, List<UserBookmarkMyPageQueryDto> bookmarkList) {
+    public UserMyPageResponseDto(MyPageUserQueryDto userDto, List<MyPageParticipatingEventQueryDto> userEventList, List<MyPageBookmarkedEventQueryDto> bookmarkList) {
         this.userDto = userDto;
         this.userEventList = userEventList;
         this.bookmarkList = bookmarkList;

--- a/src/main/java/lems/cowshed/domain/event/query/MyPageBookmarkedEventQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/event/query/MyPageBookmarkedEventQueryDto.java
@@ -1,19 +1,17 @@
-package lems.cowshed.domain.user.query;
+package lems.cowshed.domain.event.query;
 
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
 import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lems.cowshed.domain.event.Event;
 import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Data
 @Schema(description = "마이 페이지 북마크 모임 정보")
-public class UserBookmarkMyPageQueryDto {
+public class MyPageBookmarkedEventQueryDto {
 
     @Schema(description = "이벤트 id", example = "1")
     private Long id;
@@ -34,7 +32,7 @@ public class UserBookmarkMyPageQueryDto {
     private Long applicants;
 
     @QueryProjection
-    public UserBookmarkMyPageQueryDto(Long id, String author, String eventName, LocalDate eventDate, BookmarkStatus status) {
+    public MyPageBookmarkedEventQueryDto(Long id, String author, String eventName, LocalDate eventDate, BookmarkStatus status) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;
@@ -43,7 +41,7 @@ public class UserBookmarkMyPageQueryDto {
     }
 
     @Builder
-    public UserBookmarkMyPageQueryDto(Long id, String author, String eventName, LocalDate eventDate, BookmarkStatus status, Long applicants) {
+    public MyPageBookmarkedEventQueryDto(Long id, String author, String eventName, LocalDate eventDate, BookmarkStatus status, Long applicants) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;
@@ -52,8 +50,8 @@ public class UserBookmarkMyPageQueryDto {
         this.applicants = applicants;
     }
 
-    public static UserBookmarkMyPageQueryDto of(Event event, long participantsCount, BookmarkStatus status){
-        return UserBookmarkMyPageQueryDto.builder()
+    public static MyPageBookmarkedEventQueryDto of(Event event, long participantsCount, BookmarkStatus status){
+        return MyPageBookmarkedEventQueryDto.builder()
                 .id(event.getId())
                 .eventName(event.getName())
                 .author(event.getAuthor())

--- a/src/main/java/lems/cowshed/domain/event/query/MyPageParticipatingEventQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/event/query/MyPageParticipatingEventQueryDto.java
@@ -1,20 +1,17 @@
-package lems.cowshed.domain.user.query;
+package lems.cowshed.domain.event.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.domain.bookmark.Bookmark;
 import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
 
 @Data
 @Schema(description = "마이 페이지 참여 모임 정보")
-public class UserEventMyPageQueryDto {
+public class MyPageParticipatingEventQueryDto {
 
     @Schema(description = "이벤트 id", example = "1")
     private Long id;
@@ -35,8 +32,8 @@ public class UserEventMyPageQueryDto {
     private Long applicants;
 
     @QueryProjection
-    public UserEventMyPageQueryDto(Long id, String author, String eventName,
-                                   LocalDate eventDate, Long applicants) {
+    public MyPageParticipatingEventQueryDto(Long id, String author, String eventName,
+                                            LocalDate eventDate, Long applicants) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;

--- a/src/main/java/lems/cowshed/domain/user/query/EventParticipantQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/user/query/EventParticipantQueryDto.java
@@ -8,11 +8,10 @@ import lems.cowshed.domain.user.Mbti;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Data
 @Schema(description = "모임에 참여한 회원 정보")
-public class UserEventQueryDto {
+public class EventParticipantQueryDto {
     @Schema(description = "이름", example = "이길동")
     private String name;
 
@@ -33,7 +32,7 @@ public class UserEventQueryDto {
     private String location;
 
     @QueryProjection
-    public UserEventQueryDto(String name, Gender gender, Mbti mbti, LocalDate birth, String location) {
+    public EventParticipantQueryDto(String name, Gender gender, Mbti mbti, LocalDate birth, String location) {
         this.name = name;
         this.gender = gender;
         this.mbti = mbti;

--- a/src/main/java/lems/cowshed/domain/user/query/MyPageUserQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/user/query/MyPageUserQueryDto.java
@@ -11,7 +11,8 @@ import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserMyPageQueryDto {
+@Schema(description = "마이페이지 회원 정보")
+public class MyPageUserQueryDto {
 
     @Schema(description = "이름", example = "하상록")
     private String name;
@@ -23,7 +24,7 @@ public class UserMyPageQueryDto {
     private Mbti mbti;
 
     @QueryProjection
-    public UserMyPageQueryDto(String name, LocalDate birth, Mbti mbti) {
+    public MyPageUserQueryDto(String name, LocalDate birth, Mbti mbti) {
         this.name = name;
         this.birth = birth;
         this.mbti = mbti;

--- a/src/main/java/lems/cowshed/domain/user/query/UserQueryRepository.java
+++ b/src/main/java/lems/cowshed/domain/user/query/UserQueryRepository.java
@@ -3,13 +3,14 @@ package lems.cowshed.domain.user.query;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
-import lems.cowshed.api.controller.dto.event.response.QEventPreviewResponseDto;
 import lems.cowshed.api.controller.dto.user.response.UserMyPageResponseDto;
+import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
+import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
+import lems.cowshed.domain.event.query.QMyPageBookmarkedEventQueryDto;
+import lems.cowshed.domain.event.query.QMyPageParticipatingEventQueryDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
 import static lems.cowshed.domain.bookmark.QBookmark.*;
@@ -30,9 +31,9 @@ public class UserQueryRepository {
     }
 
     // 모임에 참가한 회원 정보
-    public List<UserEventQueryDto> findUserParticipatingInEvent (Long userId) {
+    public List<EventParticipantQueryDto> findUserParticipatingInEvent (Long userId) {
         return queryFactory
-                .select(new QUserEventQueryDto(
+                .select(new QEventParticipantQueryDto(
                         user.username,
                         user.gender,
                         user.mbti,
@@ -47,8 +48,8 @@ public class UserQueryRepository {
 
     public UserMyPageResponseDto findUserForMyPage(Long userId, List<Long> eventIdList) {
 
-        UserMyPageQueryDto userDto = queryFactory
-                .select(new QUserMyPageQueryDto(
+        MyPageUserQueryDto userDto = queryFactory
+                .select(new QMyPageUserQueryDto(
                         user.username.as("name"),
                         user.birth,
                         user.mbti
@@ -58,8 +59,8 @@ public class UserQueryRepository {
                 .fetchOne();
 
         // 회원이 참여한 모임과 참여 인원수 북마크 여부 X
-        List<UserEventMyPageQueryDto> userEventDto = queryFactory
-                .select(new QUserEventMyPageQueryDto(
+        List<MyPageParticipatingEventQueryDto> userEventDto = queryFactory
+                .select(new QMyPageParticipatingEventQueryDto(
                         event.id,
                         event.author,
                         event.name.as("eventName"),
@@ -73,8 +74,8 @@ public class UserQueryRepository {
                 .fetch();
 
         // 북마크 여부 O 참여자 수 체크 X
-        List<UserBookmarkMyPageQueryDto> bookmarks = queryFactory
-                .select(new QUserBookmarkMyPageQueryDto(
+        List<MyPageBookmarkedEventQueryDto> bookmarks = queryFactory
+                .select(new QMyPageBookmarkedEventQueryDto(
                                 event.id.as("eventId"),
                                 event.author,
                                 event.name,

--- a/src/main/java/lems/cowshed/service/UserService.java
+++ b/src/main/java/lems/cowshed/service/UserService.java
@@ -1,19 +1,17 @@
 package lems.cowshed.service;
 
-import lems.cowshed.api.controller.dto.event.response.EventPreviewResponseDto;
 import lems.cowshed.api.controller.dto.user.request.UserEditRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserLoginRequestDto;
 import lems.cowshed.api.controller.dto.user.request.UserSaveRequestDto;
 import lems.cowshed.api.controller.dto.user.response.UserEventResponseDto;
 import lems.cowshed.api.controller.dto.user.response.UserMyPageResponseDto;
 import lems.cowshed.api.controller.dto.user.response.UserResponseDto;
-import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
 import lems.cowshed.domain.user.Role;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
-import lems.cowshed.domain.user.query.UserBookmarkMyPageQueryDto;
-import lems.cowshed.domain.user.query.UserEventMyPageQueryDto;
-import lems.cowshed.domain.user.query.UserEventQueryDto;
+import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
+import lems.cowshed.domain.user.query.EventParticipantQueryDto;
 import lems.cowshed.domain.user.query.UserQueryRepository;
 import lems.cowshed.exception.*;
 import lombok.RequiredArgsConstructor;
@@ -23,16 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static lems.cowshed.domain.event.QEvent.event;
-import static lems.cowshed.domain.userevent.QUserEvent.userEvent;
 import static lems.cowshed.exception.Message.*;
 import static lems.cowshed.exception.Reason.*;
-import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -48,18 +42,18 @@ public class UserService {
         UserMyPageResponseDto myPageDto = userQueryRepository.findUserForMyPage(userId, participatedEventIdList);
         Set<Long> bookmarkEventIdSet = userQueryRepository.getBookmark(userId, participatedEventIdList);
 
-        List<UserEventMyPageQueryDto> userEventList = myPageDto.getUserEventList();
+        List<MyPageParticipatingEventQueryDto> userEventList = myPageDto.getUserEventList();
         checkBookmarked(userEventList, bookmarkEventIdSet);
 
-        List<UserBookmarkMyPageQueryDto> bookmarkList = myPageDto.getBookmarkList();
-        List<Long> bookmarkEventIdList = bookmarkList.stream().map(UserBookmarkMyPageQueryDto::getId).toList();
+        List<MyPageBookmarkedEventQueryDto> bookmarkList = myPageDto.getBookmarkList();
+        List<Long> bookmarkEventIdList = bookmarkList.stream().map(MyPageBookmarkedEventQueryDto::getId).toList();
         Map<Long, Long> eventIdParticipantsMap = userQueryRepository.getParticipatedEventIdSet(bookmarkEventIdList);
         setApplicants(bookmarkList, eventIdParticipantsMap);
         return myPageDto;
     }
 
     public UserEventResponseDto findUserParticipatingInEvent(LocalDate currentYear, Long userId){
-        List<UserEventQueryDto> userEventDtoList = userQueryRepository.findUserParticipatingInEvent(userId);
+        List<EventParticipantQueryDto> userEventDtoList = userQueryRepository.findUserParticipatingInEvent(userId);
         calculateAndSetDtoAge(currentYear, userEventDtoList);
 
         return new UserEventResponseDto(userEventDtoList);
@@ -112,8 +106,8 @@ public class UserService {
         return UserResponseDto.from(user);
     }
 
-    private void calculateAndSetDtoAge(LocalDate currentYear, List<UserEventQueryDto> userEventDtoList) {
-        userEventDtoList.forEach((UserEventQueryDto dto) -> {
+    private void calculateAndSetDtoAge(LocalDate currentYear, List<EventParticipantQueryDto> userEventDtoList) {
+        userEventDtoList.forEach((EventParticipantQueryDto dto) -> {
             if (dto.getBirth() == null){
                 dto.setAge(null);
             }
@@ -131,7 +125,7 @@ public class UserService {
         return !editDto.getUsername().equals(myUsername);
     }
 
-    private void checkBookmarked(List<UserEventMyPageQueryDto> userEventList, Set<Long> bookmarkEventIdSet) {
+    private void checkBookmarked(List<MyPageParticipatingEventQueryDto> userEventList, Set<Long> bookmarkEventIdSet) {
         userEventList.stream().forEach(dto -> {
             if(bookmarkEventIdSet.contains(dto.getId())){
                 dto.statusBookmark();
@@ -142,7 +136,7 @@ public class UserService {
         });
     }
 
-    private void setApplicants(List<UserBookmarkMyPageQueryDto> bookmarkList, Map<Long, Long> eventIdParticipantsMap) {
+    private void setApplicants(List<MyPageBookmarkedEventQueryDto> bookmarkList, Map<Long, Long> eventIdParticipantsMap) {
         bookmarkList.stream().forEach(
                 dto -> dto.changeApplicants(eventIdParticipantsMap.getOrDefault(dto.getId(), 0L))
         );

--- a/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
@@ -3,7 +3,6 @@ package lems.cowshed.domain.user.query;
 import lems.cowshed.api.controller.dto.user.response.UserMyPageResponseDto;
 import lems.cowshed.domain.bookmark.Bookmark;
 import lems.cowshed.domain.bookmark.BookmarkRepository;
-import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.event.EventJpaRepository;
 import lems.cowshed.domain.user.Mbti;
@@ -11,7 +10,6 @@ import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
 import lems.cowshed.domain.userevent.UserEvent;
 import lems.cowshed.domain.userevent.UserEventRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +56,7 @@ class UserQueryRepositoryTest {
         userEventRepository.save(userEvent);
 
         //when
-        List<UserEventQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
+        List<EventParticipantQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
 
         //then
         assertThat(userEventDto.get(0))
@@ -76,7 +74,7 @@ class UserQueryRepositoryTest {
         userRepository.save(user);
 
         //when
-        List<UserEventQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
+        List<EventParticipantQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
 
         //then
         assertThat(userEventDto).isEmpty();


### PR DESCRIPTION
##
### 🌱 작업 내용
[ query dto 이름 변경 및 정리 ]
- queryDto 조회 대상에 따라 도메인 분류 ( 회원 조회 user/query )
- 알기 쉬운 이름으로 변경 ( userEvent -> EventParticipant )

[ 개선 해야할 사항 ]
- userEvent 라는 이름은 모호하다. Participants 처럼 참여자라는 의미가 더 좋지 않을까?