### PR TITLE
회원 마이 페이지 조회 정리

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
@@ -5,6 +5,7 @@ import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
 import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
 import lems.cowshed.domain.user.query.MyPageUserQueryDto;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -24,9 +25,20 @@ public class UserMyPageResponseDto {
     @Schema(description = "북마크 모임")
     private List<MyPageBookmarkedEventQueryDto> bookmarkList;
 
+    @Builder
     public UserMyPageResponseDto(MyPageUserQueryDto userDto, List<MyPageParticipatingEventQueryDto> userEventList, List<MyPageBookmarkedEventQueryDto> bookmarkList) {
         this.userDto = userDto;
         this.userEventList = userEventList;
         this.bookmarkList = bookmarkList;
+    }
+
+    public static UserMyPageResponseDto of(MyPageUserQueryDto userDto,
+                                           List<MyPageParticipatingEventQueryDto> userEventList,
+                                           List<MyPageBookmarkedEventQueryDto> bookmarkList){
+        return UserMyPageResponseDto.builder()
+                .userDto(userDto)
+                .userEventList(userEventList)
+                .bookmarkList(bookmarkList)
+                .build();
     }
 }

--- a/src/main/java/lems/cowshed/domain/event/query/MyPageBookmarkedEventQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/event/query/MyPageBookmarkedEventQueryDto.java
@@ -61,7 +61,4 @@ public class MyPageBookmarkedEventQueryDto {
                 .build();
     }
 
-    public void changeApplicants(Long applicants){
-        this.applicants = applicants;
-    }
 }

--- a/src/main/java/lems/cowshed/domain/event/query/MyPageParticipatingEventQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/event/query/MyPageParticipatingEventQueryDto.java
@@ -48,4 +48,5 @@ public class MyPageParticipatingEventQueryDto {
     public void statusNotBookmark(){
         this.status = NOT_BOOKMARK;
     }
+
 }


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 회원 마이 페이지 조회 정리 ]
- 회원 조회, 참여한 모임 조회, 북마크한 모임 조회 분리
- 데이터 접근 계층에서 쿼리 하는것 이외 비즈니스 로직 이전
