### PR TITLE
참가 / 북마크한 모임 페이징 추가

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/event/response/BookmarkedEventsPagingInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/response/BookmarkedEventsPagingInfo.java
@@ -1,6 +1,7 @@
 package lems.cowshed.api.controller.dto.event.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lems.cowshed.domain.event.query.BookmarkedEventSimpleInfoQuery;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,21 +12,16 @@ import java.util.List;
 public class BookmarkedEventsPagingInfo {
 
     @Schema(description = "북마크 모임 리스트")
-    List<EventSimpleInfo> bookmarks;
-
-    boolean isLast;
+    List<BookmarkedEventSimpleInfoQuery> bookmarks;
 
     @Builder
-    public BookmarkedEventsPagingInfo(List<EventSimpleInfo> bookmarks, boolean isLast) {
+    public BookmarkedEventsPagingInfo(List<BookmarkedEventSimpleInfoQuery> bookmarks) {
         this.bookmarks = bookmarks;
-        this.isLast = isLast;
     }
 
-    public static BookmarkedEventsPagingInfo of(List<EventSimpleInfo> bookmarks, boolean isLast){
+    public static BookmarkedEventsPagingInfo of(List<BookmarkedEventSimpleInfoQuery> bookmarks){
         return BookmarkedEventsPagingInfo.builder()
                 .bookmarks(bookmarks)
-                .isLast(isLast)
                 .build();
     }
-
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/event/response/ParticipatingEventsPagingInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/response/ParticipatingEventsPagingInfo.java
@@ -1,0 +1,26 @@
+package lems.cowshed.api.controller.dto.event.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lems.cowshed.domain.event.query.ParticipatingEventSimpleInfoQuery;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "참여한 모임 반환")
+public class ParticipatingEventsPagingInfo {
+
+    private List<ParticipatingEventSimpleInfoQuery> participatingEvents;
+
+    @Builder
+    public ParticipatingEventsPagingInfo(List<ParticipatingEventSimpleInfoQuery> participatingEvents) {
+        this.participatingEvents = participatingEvents;
+    }
+
+    public static ParticipatingEventsPagingInfo from(List<ParticipatingEventSimpleInfoQuery> participatingEvents){
+        return ParticipatingEventsPagingInfo.builder()
+                .participatingEvents(participatingEvents)
+                .build();
+    }
+}

--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/UserMyPageResponseDto.java
@@ -1,8 +1,8 @@
 package lems.cowshed.api.controller.dto.user.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
-import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
+import lems.cowshed.domain.event.query.BookmarkedEventSimpleInfoQuery;
+import lems.cowshed.domain.event.query.ParticipatingEventSimpleInfoQuery;
 import lems.cowshed.domain.user.query.MyPageUserQueryDto;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,21 +20,21 @@ public class UserMyPageResponseDto {
     private MyPageUserQueryDto userDto;
 
     @Schema(description = "참여 모임")
-    private List<MyPageParticipatingEventQueryDto> userEventList;
+    private List<ParticipatingEventSimpleInfoQuery> userEventList;
 
     @Schema(description = "북마크 모임")
-    private List<MyPageBookmarkedEventQueryDto> bookmarkList;
+    private List<BookmarkedEventSimpleInfoQuery> bookmarkList;
 
     @Builder
-    public UserMyPageResponseDto(MyPageUserQueryDto userDto, List<MyPageParticipatingEventQueryDto> userEventList, List<MyPageBookmarkedEventQueryDto> bookmarkList) {
+    public UserMyPageResponseDto(MyPageUserQueryDto userDto, List<ParticipatingEventSimpleInfoQuery> userEventList, List<BookmarkedEventSimpleInfoQuery> bookmarkList) {
         this.userDto = userDto;
         this.userEventList = userEventList;
         this.bookmarkList = bookmarkList;
     }
 
     public static UserMyPageResponseDto of(MyPageUserQueryDto userDto,
-                                           List<MyPageParticipatingEventQueryDto> userEventList,
-                                           List<MyPageBookmarkedEventQueryDto> bookmarkList){
+                                           List<ParticipatingEventSimpleInfoQuery> userEventList,
+                                           List<BookmarkedEventSimpleInfoQuery> bookmarkList){
         return UserMyPageResponseDto.builder()
                 .userDto(userDto)
                 .userEventList(userEventList)

--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -6,6 +6,7 @@ import lems.cowshed.api.controller.dto.event.response.EventInfo;
 import lems.cowshed.api.controller.dto.event.response.EventsPagingInfo;
 import lems.cowshed.api.controller.dto.event.request.EventSaveRequestDto;
 import lems.cowshed.api.controller.dto.event.request.EventUpdateRequestDto;
+import lems.cowshed.api.controller.dto.event.response.ParticipatingEventsPagingInfo;
 import lems.cowshed.service.CustomUserDetails;
 import lems.cowshed.service.EventService;
 import lombok.RequiredArgsConstructor;
@@ -37,10 +38,17 @@ public class EventController implements EventSpecification {
     }
 
     @GetMapping("/bookmarks")
-    public CommonResponse<BookmarkedEventsPagingInfo> getPagingBookmarkedEvents(@PageableDefault(page = 0, size = 10) Pageable pageable,
+    public CommonResponse<BookmarkedEventsPagingInfo> getBookmarkedEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
                                                                                 @AuthenticationPrincipal CustomUserDetails userDetails){
-        BookmarkedEventsPagingInfo bookmarkEvents = eventService.getPagingBookmarkedEvents(pageable, userDetails.getUserId());
+        BookmarkedEventsPagingInfo bookmarkEvents = eventService.getBookmarkedEventsPaging(pageable, userDetails.getUserId());
         return CommonResponse.success(bookmarkEvents);
+    }
+
+    @GetMapping("/participating")
+    public CommonResponse<ParticipatingEventsPagingInfo> getParticipatingEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
+                                                                            @AuthenticationPrincipal CustomUserDetails userDetails){
+        ParticipatingEventsPagingInfo ParticipatingEvents = eventService.getParticipatingEventsPaging(pageable, userDetails.getUserId());
+        return CommonResponse.success(ParticipatingEvents);
     }
 
     @PostMapping

--- a/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
@@ -9,10 +9,12 @@ import lems.cowshed.api.controller.dto.event.response.EventInfo;
 import lems.cowshed.api.controller.dto.event.response.EventsPagingInfo;
 import lems.cowshed.api.controller.dto.event.request.EventSaveRequestDto;
 import lems.cowshed.api.controller.dto.event.request.EventUpdateRequestDto;
+import lems.cowshed.api.controller.dto.event.response.ParticipatingEventsPagingInfo;
 import lems.cowshed.config.swagger.ApiErrorCodeExample;
 import lems.cowshed.config.swagger.ApiErrorCodeExamples;
 import lems.cowshed.service.CustomUserDetails;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -56,8 +58,12 @@ public interface EventSpecification {
     CommonResponse<Void> deleteEvent(@PathVariable("event-id") Long eventId,
                                      @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
-    @Operation(summary = "북마크 모임 페이징 조회", description = "북마크 모임 페이징 조회")
-    CommonResponse<BookmarkedEventsPagingInfo> getPagingBookmarkedEvents(Pageable pageable,
+    @Operation(summary = "북마크 모임 페이징 조회", description = "북마크 모임 페이징 조회 합니다.")
+    CommonResponse<BookmarkedEventsPagingInfo> getBookmarkedEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
                                                                          @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "참여 모임 페이징 조회", description = "참여 모임 페이징 조회 합니다.")
+    CommonResponse<ParticipatingEventsPagingInfo> getParticipatingEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
+                                                                               @AuthenticationPrincipal CustomUserDetails userDetails);
 
 }

--- a/src/main/java/lems/cowshed/domain/event/query/BookmarkedEventSimpleInfoQuery.java
+++ b/src/main/java/lems/cowshed/domain/event/query/BookmarkedEventSimpleInfoQuery.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 
 @Data
 @Schema(description = "마이 페이지 북마크 모임 정보")
-public class MyPageBookmarkedEventQueryDto {
+public class BookmarkedEventSimpleInfoQuery {
 
     @Schema(description = "이벤트 id", example = "1")
     private Long id;
@@ -35,8 +35,8 @@ public class MyPageBookmarkedEventQueryDto {
     private int capacity;
 
     @QueryProjection
-    public MyPageBookmarkedEventQueryDto(Long id, String author, String eventName,
-                                         LocalDate eventDate, BookmarkStatus status, int capacity) {
+    public BookmarkedEventSimpleInfoQuery(Long id, String author, String eventName,
+                                          LocalDate eventDate, BookmarkStatus status, int capacity) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;
@@ -46,8 +46,8 @@ public class MyPageBookmarkedEventQueryDto {
     }
 
     @Builder
-    public MyPageBookmarkedEventQueryDto(Long id, String author, String eventName, LocalDate eventDate,
-                                         BookmarkStatus status, Long applicants, int capacity) {
+    public BookmarkedEventSimpleInfoQuery(Long id, String author, String eventName, LocalDate eventDate,
+                                          BookmarkStatus status, Long applicants, int capacity) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;
@@ -57,8 +57,8 @@ public class MyPageBookmarkedEventQueryDto {
         this.capacity = capacity;
     }
 
-    public static MyPageBookmarkedEventQueryDto of(Event event, long participantsCount, BookmarkStatus status){
-        return MyPageBookmarkedEventQueryDto.builder()
+    public static BookmarkedEventSimpleInfoQuery of(Event event, long participantsCount, BookmarkStatus status){
+        return BookmarkedEventSimpleInfoQuery.builder()
                 .id(event.getId())
                 .eventName(event.getName())
                 .author(event.getAuthor())

--- a/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
@@ -50,10 +50,10 @@ public class EventQueryRepository {
                 .fetchOne();
     }
 
-    public List<MyPageParticipatingEventQueryDto> findParticipatedEvents(List<Long> eventIds) {
+    public List<ParticipatingEventSimpleInfoQuery> findParticipatedEvents(List<Long> eventIds) {
         // 회원이 참여한 모임과 참여 인원수 북마크 여부 X
         return queryFactory
-                .select(new QMyPageParticipatingEventQueryDto(
+                .select(new QParticipatingEventSimpleInfoQuery(
                         event.id,
                         event.author,
                         event.name.as("eventName"),
@@ -68,10 +68,10 @@ public class EventQueryRepository {
                 .fetch();
     }
 
-    public List<MyPageBookmarkedEventQueryDto> findBookmarkedEvents(Long userId, Pageable pageable) {
+    public List<BookmarkedEventSimpleInfoQuery> findBookmarkedEventsPaging(Long userId, Pageable pageable) {
         // 북마크 여부 O 참여 인원수 X
         return queryFactory
-                .select(new QMyPageBookmarkedEventQueryDto(
+                .select(new QBookmarkedEventSimpleInfoQuery(
                                 event.id.as("eventId"),
                                 event.author,
                                 event.name,
@@ -86,6 +86,7 @@ public class EventQueryRepository {
                         .and(bookmark.user.id.eq(userId))
                         .and(bookmark.status.eq(BOOKMARK)))
                 .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
                 .fetch();
     }
 
@@ -96,6 +97,7 @@ public class EventQueryRepository {
                 .from(userEvent)
                 .where(userEvent.user.id.eq(userId))
                 .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
                 .fetch();
     }
 

--- a/src/main/java/lems/cowshed/domain/event/query/ParticipatingEventSimpleInfoQuery.java
+++ b/src/main/java/lems/cowshed/domain/event/query/ParticipatingEventSimpleInfoQuery.java
@@ -11,7 +11,7 @@ import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
 
 @Data
 @Schema(description = "마이 페이지 참여 모임 정보")
-public class MyPageParticipatingEventQueryDto {
+public class ParticipatingEventSimpleInfoQuery {
 
     @Schema(description = "이벤트 id", example = "1")
     private Long id;
@@ -35,8 +35,8 @@ public class MyPageParticipatingEventQueryDto {
     private int capacity;
 
     @QueryProjection
-    public MyPageParticipatingEventQueryDto(Long id, String author, String eventName,
-                                            LocalDate eventDate, Long applicants, int capacity) {
+    public ParticipatingEventSimpleInfoQuery(Long id, String author, String eventName,
+                                             LocalDate eventDate, Long applicants, int capacity) {
         this.id = id;
         this.author = author;
         this.eventName = eventName;

--- a/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
@@ -7,7 +7,6 @@ import lems.cowshed.domain.event.EventJpaRepository;
 import lems.cowshed.domain.user.Mbti;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
-import lems.cowshed.domain.user.query.UserQueryRepository;
 import lems.cowshed.domain.userevent.UserEvent;
 import lems.cowshed.domain.userevent.UserEventRepository;
 import org.assertj.core.groups.Tuple;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +25,6 @@ import static lems.cowshed.domain.bookmark.BookmarkStatus.BOOKMARK;
 import static lems.cowshed.domain.user.Mbti.ESFJ;
 import static lems.cowshed.domain.user.Mbti.INTP;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -72,7 +69,7 @@ class EventQueryRepositoryTest {
         userEventRepository.saveAll(List.of(userEvent,userEvent2));
 
         //when
-        List<MyPageParticipatingEventQueryDto> response = eventQueryRepository.findParticipatedEvents(List.of(event.getId()));
+        List<ParticipatingEventSimpleInfoQuery> response = eventQueryRepository.findParticipatedEvents(List.of(event.getId()));
 
         //then
         assertThat(response).hasSize(1)
@@ -93,8 +90,8 @@ class EventQueryRepositoryTest {
         bookmarkRepository.save(bookmark);
 
         //when
-        List<MyPageBookmarkedEventQueryDto> response = eventQueryRepository
-                .findBookmarkedEvents(user.getId(), PageRequest.of(0, 5));
+        List<BookmarkedEventSimpleInfoQuery> response = eventQueryRepository
+                .findBookmarkedEventsPaging(user.getId(), PageRequest.of(0, 5));
 
         //then
         assertThat(response).hasSize(1)

--- a/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
@@ -1,17 +1,13 @@
 package lems.cowshed.domain.user.query;
 
 import lems.cowshed.domain.bookmark.Bookmark;
-import lems.cowshed.domain.bookmark.BookmarkRepository;
 import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.event.EventJpaRepository;
-import lems.cowshed.domain.event.query.MyPageBookmarkedEventQueryDto;
-import lems.cowshed.domain.event.query.MyPageParticipatingEventQueryDto;
 import lems.cowshed.domain.user.Mbti;
 import lems.cowshed.domain.user.User;
 import lems.cowshed.domain.user.UserRepository;
 import lems.cowshed.domain.userevent.UserEvent;
 import lems.cowshed.domain.userevent.UserEventRepository;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/lems/cowshed/service/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/EventServiceTest.java
@@ -387,12 +387,12 @@ class EventServiceTest {
         Pageable pageable = PageRequest.of(0, 3);
 
         //when
-        BookmarkedEventsPagingInfo bookmarkEvents = eventService.getPagingBookmarkedEvents(pageable, user.getId());
+        BookmarkedEventsPagingInfo bookmarkEvents = eventService.getBookmarkedEventsPaging(pageable, user.getId());
 
         //then
         assertThat(bookmarkEvents.getBookmarks())
                 .hasSize(3)
-                .extracting("name")
+                .extracting("eventName")
                 .containsExactlyInAnyOrder("테스트0", "테스트1", "테스트2");
     }
 


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 참가 / 북마크한 모임 페이징 조회 추가 ]
- 마이 페이지 참가 / 북마크한 모임 로직과 같다.
- 마이 페이지는 고정된 5개 / 페이징은 Pageable를 통해 찾는다.

[ 응답 객체 이름 변경 ]
- MyPageParticipatingEventQueryDto To ParticipatingEventSimpleInfoQuery
- MyPageBookmarkedEventQueryDto To BookmarkedEventSimpleInfoQuery
