### PR TITLE
회원 삭제 / 특정 모임에 참여한 회원 조회 추가

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/user/response/ParticipatingUserListInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/user/response/ParticipatingUserListInfo.java
@@ -12,5 +12,5 @@ import java.util.List;
 @AllArgsConstructor
 public class ParticipatingUserListInfo {
 
-    private List<EventParticipantQueryDto> userList;
+    private List<EventParticipantQueryDto> participants;
 }

--- a/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
@@ -30,12 +30,10 @@ public class UserApiController implements UserSpecification{
         return CommonResponse.success(myPage);
     }
 
-    @GetMapping("/{event-id}")
-    public CommonResponse<ParticipatingUserListInfo> findUserParticipatingInEvent(@PathVariable("event-id") long eventId,
-                                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails){
-        LocalDate now = LocalDate.now();
-        ParticipatingUserListInfo userEvent = userService.findUserParticipatingInEvent(now, customUserDetails.getUserId());
-        return CommonResponse.success(userEvent);
+    @GetMapping("/events/{event-id}")
+    public CommonResponse<ParticipatingUserListInfo> findParticipants(@PathVariable("event-id") Long eventId){
+        ParticipatingUserListInfo participatingUser = userService.findParticipants(eventId);
+        return CommonResponse.success(participatingUser);
     }
 
     @PostMapping("/signUp")

--- a/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserApiController.java
@@ -75,4 +75,9 @@ public class UserApiController implements UserSpecification{
         return CommonResponse.success(response);
     }
 
+    @DeleteMapping
+    public CommonResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        userService.deleteUser(customUserDetails.getUserId());
+        return CommonResponse.success();
+    }
 }

--- a/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
@@ -35,9 +35,8 @@ public interface UserSpecification {
     CommonResponse<Void> editUser(@RequestBody UserEditRequestDto UserEditRequestDto,
                                   @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
-    @Operation(summary = "모임 회원 조회", description = "특정 모임에 속한 다수 회원을 조회 합니다. [이벤트 상세 > 참여자 목록]")
-    CommonResponse<ParticipatingUserListInfo> findUserParticipatingInEvent(@PathVariable("event-id")  long eventId,
-                                                                           @AuthenticationPrincipal CustomUserDetails customUserDetails);
+    @Operation(summary = "모임에 참여한 회원 조회", description = "특정 모임에 참여한 회원들을 조회 합니다. [이벤트 상세 > 참여자 목록]")
+    CommonResponse<ParticipatingUserListInfo> findParticipants(@PathVariable("event-id") Long eventId);
 
     @Operation(summary = "회원 조회", description = "회원의 세부 사항을 조회 합니다.")
     @ApiErrorCodeExample(ErrorCode.NOT_FOUND_ERROR)

--- a/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserSpecification.java
@@ -52,4 +52,6 @@ public interface UserSpecification {
     @Operation(summary = "회원 가입 검증", description = "중복된 이메일을 가진 회원을 찾습니다.")
     CommonResponse<UserSignUpValidationInfo> signUpValidationForEmail(@PathVariable String email);
 
+    @Operation(summary = "회원 삭제", description = "회원을 삭제 합니다.")
+    CommonResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails);
 }

--- a/src/main/java/lems/cowshed/domain/user/query/EventParticipantQueryDto.java
+++ b/src/main/java/lems/cowshed/domain/user/query/EventParticipantQueryDto.java
@@ -1,13 +1,9 @@
 package lems.cowshed.domain.user.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lems.cowshed.domain.user.Gender;
-import lems.cowshed.domain.user.Mbti;
 import lombok.Data;
-
-import java.time.LocalDate;
 
 @Data
 @Schema(description = "모임에 참여한 회원 정보")
@@ -15,28 +11,12 @@ public class EventParticipantQueryDto {
     @Schema(description = "이름", example = "이길동")
     private String name;
 
-    @Schema(description = "성별", example = "M")
+    @Schema(description = "성별", example = "MALE")
     private Gender gender;
 
-    @Schema(description = "mbti", example = "INTP")
-    private Mbti mbti;
-
-    @Schema(description = "나이", example = "26")
-    private Integer age;
-
-    @JsonIgnore
-    @Schema(description = "생일", example = "2020-01-01")
-    private LocalDate birth;
-
-    @Schema(description = "지역", example = "대구 광역시 수성구")
-    private String location;
-
     @QueryProjection
-    public EventParticipantQueryDto(String name, Gender gender, Mbti mbti, LocalDate birth, String location) {
+    public EventParticipantQueryDto(String name, Gender gender) {
         this.name = name;
         this.gender = gender;
-        this.mbti = mbti;
-        this.birth = birth;
-        this.location = location;
     }
 }

--- a/src/main/java/lems/cowshed/domain/user/query/UserQueryRepository.java
+++ b/src/main/java/lems/cowshed/domain/user/query/UserQueryRepository.java
@@ -20,19 +20,16 @@ public class UserQueryRepository {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    // 모임에 참가한 회원 정보
-    public List<EventParticipantQueryDto> findUserParticipatingInEvent (Long userId) {
+    // 특정 모임에 참여한 회원들 정보
+    public List<EventParticipantQueryDto> findParticipants (Long eventId) {
         return queryFactory
                 .select(new QEventParticipantQueryDto(
-                        user.username,
-                        user.gender,
-                        user.mbti,
-                        user.birth,
-                        user.location
+                        user.username.as("name"),
+                        user.gender
                 ))
                 .from(userEvent)
                 .join(userEvent.user, user)
-                .where(user.id.eq(userId))
+                .on(userEvent.event.id.eq(eventId))
                 .fetch();
     }
 

--- a/src/main/java/lems/cowshed/service/UserService.java
+++ b/src/main/java/lems/cowshed/service/UserService.java
@@ -111,6 +111,13 @@ public class UserService {
         return UserInfo.from(user);
     }
 
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
+
+        userRepository.delete(user);
+    }
+
     private void calculateAndSetDtoAge(LocalDate currentYear, List<EventParticipantQueryDto> userEventDtoList) {
         userEventDtoList.forEach((EventParticipantQueryDto dto) -> {
             if (dto.getBirth() == null){
@@ -154,4 +161,5 @@ public class UserService {
         return participatedEvents.stream()
                 .map(ParticipatingEventSimpleInfoQuery::getId).toList();
     }
+
 }

--- a/src/main/java/lems/cowshed/service/UserService.java
+++ b/src/main/java/lems/cowshed/service/UserService.java
@@ -22,9 +22,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -57,10 +54,8 @@ public class UserService {
         return UserMyPageInfo.of(userDto, participatedEvents, bookmarkedEventList);
     }
 
-    public ParticipatingUserListInfo findUserParticipatingInEvent(LocalDate currentYear, Long userId){
-        List<EventParticipantQueryDto> userEventDtoList = userQueryRepository.findUserParticipatingInEvent(userId);
-        calculateAndSetDtoAge(currentYear, userEventDtoList);
-
+    public ParticipatingUserListInfo findParticipants(Long eventId){
+        List<EventParticipantQueryDto> userEventDtoList = userQueryRepository.findParticipants(eventId);
         return new ParticipatingUserListInfo(userEventDtoList);
     }
 
@@ -116,17 +111,6 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
 
         userRepository.delete(user);
-    }
-
-    private void calculateAndSetDtoAge(LocalDate currentYear, List<EventParticipantQueryDto> userEventDtoList) {
-        userEventDtoList.forEach((EventParticipantQueryDto dto) -> {
-            if (dto.getBirth() == null){
-                dto.setAge(null);
-            }
-            else {
-                dto.setAge((int) ChronoUnit.YEARS.between(dto.getBirth(), currentYear) + 1);
-            }
-        });
     }
 
     private boolean isPasswordValidationFail(UserLoginRequestDto loginDto, User user) {

--- a/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/user/query/UserQueryRepositoryTest.java
@@ -1,6 +1,5 @@
 package lems.cowshed.domain.user.query;
 
-import lems.cowshed.domain.bookmark.Bookmark;
 import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.event.EventJpaRepository;
 import lems.cowshed.domain.user.Mbti;
@@ -15,10 +14,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-
 import java.util.List;
 
-import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
 import static lems.cowshed.domain.user.Mbti.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -39,9 +36,9 @@ class UserQueryRepositoryTest {
     @Autowired
     UserEventRepository userEventRepository;
 
-    @DisplayName("모임에 참여한 회원을 조회 한다.")
+    @DisplayName("모임에 참여한 회원들을 조회 한다.")
     @Test
-    void findUserParticipatingInEvent() {
+    void findParticipants() {
         //given
         User user = createUser("테스터", INTP);
         userRepository.save(user);
@@ -51,17 +48,17 @@ class UserQueryRepositoryTest {
         userEventRepository.save(userEvent);
 
         //when
-        List<EventParticipantQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
+        List<EventParticipantQueryDto> result = userQueryRepository.findParticipants(event.getId());
 
         //then
-        assertThat(userEventDto.get(0))
-                .extracting("name", "mbti")
-                .containsExactly("테스터", INTP);
+        assertThat(result.get(0))
+                .extracting("name")
+                .isEqualTo("테스터");
     }
 
-    @DisplayName("모임에 참여한 회원을 조회 할때 참여한 회원이 없다면 빈 리스트를 반환 한다.")
+    @DisplayName("모임에 참여한 회원들을 조회 할때 참여한 회원이 없다면 빈 리스트를 반환 한다.")
     @Test
-    void findUserParticipatingInEventWhenZeroParticipating() {
+    void findParticipantsWhenZeroParticipating() {
         //given
         User user = createUser("테스터", INTP);
         userRepository.save(user);
@@ -69,18 +66,34 @@ class UserQueryRepositoryTest {
         eventJpaRepository.save(event);
 
         //when
-        List<EventParticipantQueryDto> userEventDto = userQueryRepository.findUserParticipatingInEvent(user.getId());
+        List<EventParticipantQueryDto> result = userQueryRepository.findParticipants(event.getId());
 
         //then
-        assertThat(userEventDto).isEmpty();
+        assertThat(result).isEmpty();
     }
 
-    private Bookmark createBookmark(Event event, User user) {
-        return Bookmark.builder()
-                .event(event)
-                .user(user)
-                .status(BOOKMARK)
-                .build();
+    @DisplayName("두명의 회원이 같은 모임에 참여 했을때 모임의 참여자들을 확인 한다.")
+    @Test
+    void findParticipantsWhenTwoUserParticipating() {
+        //given
+        User user = createUser("테스터", INTP);
+        User user2 = createUser("테스터2", ESFJ);
+        Event event = createEvent("산책 모임", "테스터");
+
+        UserEvent userEvent = UserEvent.of(user, event);
+        UserEvent userEvent2 = UserEvent.of(user2, event);
+
+        userRepository.saveAll(List.of(user, user2));
+        eventJpaRepository.save(event);
+        userEventRepository.saveAll(List.of(userEvent, userEvent2));
+
+        //when
+        List<EventParticipantQueryDto> result = userQueryRepository.findParticipants(event.getId());
+
+        //then
+        assertThat(result).hasSize(2)
+                .extracting("name")
+                .containsExactlyInAnyOrder("테스터", "테스터2");
     }
 
     private User createUser(String username, Mbti mbti) {


### PR DESCRIPTION
##
### 🌱 [ 특정 모임에 참여한 회원 조회 ]
[ URL 수정 ]
- /{event-id} To /events/{event-id}
- 특정 모임에 참여한 회원들이므로 모임 자원을 URL에 표시 

[ 메서드 이름 변경 ]
- findUserParticipatingInEvent To findParticipants
- 도메인에 참여자는 모임 참여자만 있기 때문에 변경 하였습니다.
- 모르는 사람이 보아도 이해가 될지 고민이 있습니다.

[ 반환 값 ]
- 모임 참여 테이블과 회원 테이블을 조인 하여 결과를 얻고 이름, 성별을 반환

[ 테스트 단수/복수 수정 ]
- 모임에 참여한 회원을 조회 한다. To 회원들을
- 단수/복수를 명확히 하면 읽는 사람에게 도움을 줄 수 있습니다.

##
### ⏰ 기타 사항
[ 회원 삭제 추가 ]
