### PR TITLE
검증 컨트롤러 도메인에 맞게 이름 URL 변경

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/user/UserVerificationController.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserVerificationController.java
@@ -1,4 +1,4 @@
-package lems.cowshed.api.controller.mail;
+package lems.cowshed.api.controller.user;
 
 import lems.cowshed.api.controller.CommonResponse;
 import lems.cowshed.api.controller.dto.verification.request.MailVerificationRequest;
@@ -12,30 +12,30 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
-import static lems.cowshed.domain.mail.code.CodeType.*;
+import static lems.cowshed.domain.mail.code.CodeType.SIGN_UP;
 
 @RequiredArgsConstructor
-@RequestMapping("/verification")
+@RequestMapping("/user/verification")
 @RestController
-public class VerificationApiController implements VerificationSpecification {
+public class UserVerificationController implements UserVerificationSpecification {
 
     private final UserService userService;
     private final MailService mailService;
     private final CodeFinder codeFinder;
 
-    @PostMapping("/mail/{mail}")
-    public CommonResponse<VerificationResultInfo> verifyMailAndSendCode(@PathVariable String mail){
-        if(userService.isExistEmail(mail)){
+    @PostMapping("/email/{email}")
+    public CommonResponse<VerificationResultInfo> verifyEmailAndSendCode(@PathVariable String email){
+        if(userService.isExistEmail(email)){
             return CommonResponse.success(VerificationResultInfo.of(false));
         }
 
         String code = codeFinder.findCodeFrom(SIGN_UP);
-        mailService.sendCodeToMail(SIGN_UP, Mail.of(mail, code));
+        mailService.sendCodeToMail(SIGN_UP, Mail.of(email, code));
         return CommonResponse.success(VerificationResultInfo.of(true));
     }
 
-    @GetMapping("/mail")
-    public CommonResponse<VerificationResultInfo> verifyMail(@RequestBody MailVerificationRequest request){
+    @GetMapping("/email/code")
+    public CommonResponse<VerificationResultInfo> verifyEmail(@RequestBody MailVerificationRequest request){
         return CommonResponse.success(mailService.verifyMail(request.toMail(), LocalDateTime.now()));
     }
 

--- a/src/main/java/lems/cowshed/api/controller/user/UserVerificationSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/user/UserVerificationSpecification.java
@@ -1,4 +1,4 @@
-package lems.cowshed.api.controller.mail;
+package lems.cowshed.api.controller.user;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,16 +10,16 @@ import lems.cowshed.config.swagger.ApiErrorCodeExample;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name="verification-controller", description="검증 API")
-public interface VerificationSpecification {
+@Tag(name="user-Verification-controller", description="회원 검증 API")
+public interface UserVerificationSpecification {
 
-    @Operation(summary = "인증 코드 전송", description = "메일 주소를 검증하고 인증 코드를 전송 합니다.")
+    @Operation(summary = "인증 코드 전송", description = "이메일 주소를 확인 후 인증 코드를 전송 합니다.")
     @ApiErrorCodeExample(ErrorCode.BUSINESS_ERROR)
-    CommonResponse<VerificationResultInfo> verifyMailAndSendCode(@PathVariable String mail);
+    CommonResponse<VerificationResultInfo> verifyEmailAndSendCode(@PathVariable String email);
 
-    @Operation(summary = "메일 검증", description = "메일 주소와 인증코드를 검증 합니다.")
+    @Operation(summary = "이메일 검증", description = "이메일 주소와 인증코드를 검증 합니다.")
     @ApiErrorCodeExample(ErrorCode.BUSINESS_ERROR)
-    CommonResponse<VerificationResultInfo> verifyMail(@RequestBody MailVerificationRequest request);
+    CommonResponse<VerificationResultInfo> verifyEmail(@RequestBody MailVerificationRequest request);
 
     @Operation(summary = "닉네임 검증", description = "중복된 닉네임이 있는지 검증 합니다.")
     CommonResponse<VerificationResultInfo> verifyUsername(@PathVariable String username);


### PR DESCRIPTION
##
### 🌱 작업 내용

### 📝 [ 검증 컨트롤러 이름 / URL 변경 ]  
[ Before ]
- 상황 : UserController API 많아짐에 따라 분리 필요
- 조치 : 검증 부분 분리 VerificationController 생성
- 고민: 통일성이 없고 어떻게 분리 하는게 좋은지 의문, 관련된 글을 찾기 어려워 인프런에 질문
- 질문 링크 : https://www.inflearn.com/community/questions/1568892/controller-service-%EB%B6%84%EB%A6%AC  

---
[ 행위에 따라 분리 하면 안되나요? ] 
- 행위에 따라 분리할 경우에도 각 도메인 로직이 모이면 Controller가 비대해진다.
-  ex) 검증 관련된 로직을 모두 VerificationController에 모을경우 다시 분리를 해야한다.

---
[ After ] 
- 도메인에 따라 분리 회원 관련 검증이므로 UserVerificationController로 변경