### PR TITLE
refactor: 모임 필드 수정 / 모임 이미지 등록 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AWS
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
@@ -1,20 +1,12 @@
 package lems.cowshed.api.controller.dto.event.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lems.cowshed.api.controller.dto.Enum;
 import lems.cowshed.domain.event.Category;
 import lems.cowshed.domain.event.Event;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Date;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,13 +21,6 @@ public class EventSaveRequestDto {
     @Schema(description = "카테고리", example = "스포츠")
     Category category;
 
-    @NotBlank
-    @Schema(description = "모임 장소", example = "여의도 한강공원")
-    String location;
-
-    @Schema(description = "모임 날짜", example = "yyyy-mm-dd")
-    LocalDate eventDate;
-
     @Max(value = 200)
     @Schema(description = "수용 인원", example = "50")
     int capacity;
@@ -44,25 +29,28 @@ public class EventSaveRequestDto {
     @Schema(description = "내용", example = "출근 전에 한강에서 같이 뛰실 분 구해요!!")
     String content;
 
+    @NotBlank
+    @Schema(description = "이미지 이름", example = "강아지.jpg")
+    String originalFileName;
+
     @Builder
-    private EventSaveRequestDto(String name, Category category, String location, LocalDate eventDate, int capacity, String content) {
+    private EventSaveRequestDto(String name, Category category,
+                                int capacity, String content, String originalFileName) {
         this.name = name;
         this.category = category;
-        this.location = location;
-        this.eventDate = eventDate;
         this.capacity = capacity;
         this.content = content;
+        this.originalFileName = originalFileName;
     }
 
     public Event toEntity(String username) {
         return Event.builder()
                 .name(this.name)
                 .category(this.category)
-                .location(this.location)
-                .eventDate(this.eventDate)
                 .capacity(this.getCapacity())
                 .author(username)
                 .content(this.content)
+                .originalFileName(this.originalFileName)
                 .build();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/request/EventSaveRequestDto.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import lems.cowshed.api.controller.dto.Enum;
+import lems.cowshed.domain.UploadFile;
 import lems.cowshed.domain.event.Category;
 import lems.cowshed.domain.event.Event;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "모임 등록")
@@ -21,36 +24,35 @@ public class EventSaveRequestDto {
     @Schema(description = "카테고리", example = "스포츠")
     Category category;
 
-    @Max(value = 200)
-    @Schema(description = "수용 인원", example = "50")
+    @Max(value = 100)
+    @Schema(description = "수용 인원 ( 최대 100명 )", example = "50")
     int capacity;
 
     @NotBlank
     @Schema(description = "내용", example = "출근 전에 한강에서 같이 뛰실 분 구해요!!")
     String content;
 
-    @NotBlank
     @Schema(description = "이미지 이름", example = "강아지.jpg")
-    String originalFileName;
+    MultipartFile file;
 
     @Builder
     private EventSaveRequestDto(String name, Category category,
-                                int capacity, String content, String originalFileName) {
+                                int capacity, String content, MultipartFile file) {
         this.name = name;
         this.category = category;
         this.capacity = capacity;
         this.content = content;
-        this.originalFileName = originalFileName;
+        this.file = file;
     }
 
-    public Event toEntity(String username) {
+    public Event toEntity(String username, UploadFile uploadFile) {
         return Event.builder()
                 .name(this.name)
                 .category(this.category)
                 .capacity(this.getCapacity())
                 .author(username)
                 .content(this.content)
-                .originalFileName(this.originalFileName)
+                .uploadFile(uploadFile)
                 .build();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/dto/event/response/EventInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/response/EventInfo.java
@@ -24,12 +24,8 @@ public class EventInfo {
     Category category;
     @Schema(description = "등록일", example = "yyyy-mm-dd hh:mm:ss")
     LocalDateTime createdDate;
-    @Schema(description = "장소 이름", example = "스카이 휘트니스")
-    String location;
     @Schema(description = "내용", example = "같이 운동하실 분 구합니다. 같이 프레스 운동 하면서 서로 보조해주실 분 구합니다.")
     String content;
-    @Schema(description = "모임 날짜", example = "2024-09-12")
-    LocalDate eventDate;
     @Schema(description = "수용 인원", example = "100")
     int capacity;
     @Schema(description = "참여 신청 인원", example = "50")
@@ -46,16 +42,14 @@ public class EventInfo {
 
     @QueryProjection
     public EventInfo(Long eventId, String name, String author, Category category,
-                     LocalDateTime createdDate, String location, String content,
-                     LocalDate eventDate, int capacity, long applicants, String userList) {
+                     LocalDateTime createdDate, String content,
+                     int capacity, long applicants, String userList) {
         this.eventId = eventId;
         this.name = name;
         this.author = author;
         this.category = category;
         this.createdDate = createdDate;
-        this.location = location;
         this.content = content;
-        this.eventDate = eventDate;
         this.capacity = capacity;
         this.applicants = applicants;
         this.userList = userList;
@@ -63,17 +57,14 @@ public class EventInfo {
 
     @Builder
     private EventInfo(Long eventId, String author, String name, Category category,
-                      LocalDateTime createdDate, String location,
-                      String content, LocalDate eventDate, int capacity, long applicants,
+                      LocalDateTime createdDate,String content, int capacity, long applicants,
                       BookmarkStatus bookmarkStatus, boolean isEventRegistrant, boolean isParticipated) {
         this.eventId = eventId;
         this.name = name;
         this.author = author;
         this.category = category;
         this.createdDate = createdDate;
-        this.location = location;
         this.content = content;
-        this.eventDate = eventDate;
         this.capacity = capacity;
         this.applicants = applicants;
         this.bookmarkStatus = bookmarkStatus;

--- a/src/main/java/lems/cowshed/api/controller/dto/event/response/EventSimpleInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/event/response/EventSimpleInfo.java
@@ -29,9 +29,6 @@ public class EventSimpleInfo implements EventIdProvider {
     @Schema(description = "모임 이름", example = "자전거 모임")
     private String name;
 
-    @Schema(description = "모임 날짜", example = "2024-09-12")
-    private LocalDate eventDate;
-
     @Schema(description = "모임 등록자", example = "김철수")
     private String author;
 
@@ -51,28 +48,24 @@ public class EventSimpleInfo implements EventIdProvider {
     private BookmarkStatus bookmarkStatus;
 
     @QueryProjection
-    public EventSimpleInfo(Long id, String name, String author,
-                           String content, LocalDate eventDate,
+    public EventSimpleInfo(Long id, String name, String author, String content,
                            int capacity, LocalDateTime createdDateTime, BookmarkStatus bookmarkStatus){
         this.id = id;
         this.name = name;
         this.author = author;
         this.content = content;
-        this.eventDate = eventDate;
         this.capacity = capacity;
         this.createdDateTime = createdDateTime;
         this.bookmarkStatus = bookmarkStatus;
     }
 
     @Builder
-    public EventSimpleInfo(Long id, String name, String author,
-                           String content, LocalDate eventDate, int capacity,
+    public EventSimpleInfo(Long id, String name, String author, String content, int capacity,
                            LocalDateTime createdDateTime, long applicants, BookmarkStatus bookmarkStatus) {
         this.id = id;
         this.name = name;
         this.author = author;
         this.content = content;
-        this.eventDate = eventDate;
         this.capacity = capacity;
         this.createdDateTime = createdDateTime;
         this.applicants = applicants;
@@ -85,7 +78,6 @@ public class EventSimpleInfo implements EventIdProvider {
                 .name(event.getName())
                 .author(event.getAuthor())
                 .content(event.getContent())
-                .eventDate(event.getEventDate())
                 .capacity(event.getCapacity())
                 .createdDateTime(event.getCreatedDateTime())
                 .applicants(participantsCount)

--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -9,10 +9,12 @@ import lems.cowshed.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,6 +37,13 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(events);
     }
 
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CommonResponse<Void> saveEvent(@ModelAttribute @Validated EventSaveRequestDto requestDto,
+                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
+        eventService.saveEvent(requestDto, customUserDetails.getUsername());
+        return CommonResponse.success();
+    }
+
     @GetMapping("/bookmarks")
     public CommonResponse<BookmarkedEventsPagingInfo> getEventsBookmarkedByUser(@PageableDefault(page = 0, size = 10) Pageable pageable,
                                                                                 @AuthenticationPrincipal CustomUserDetails userDetails){
@@ -54,13 +63,6 @@ public class EventController implements EventSpecification {
                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         EventsSearchInfo searchEvent = eventService.searchEventsByNameOrContent(keyword, customUserDetails.getUserId());
         return CommonResponse.success(searchEvent);
-    }
-
-    @PostMapping
-    public CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto,
-                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        eventService.saveEvent(requestDto, customUserDetails.getUsername());
-        return CommonResponse.success();
     }
 
     @PostMapping("/{event-id}/join")

--- a/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventSpecification.java
@@ -14,9 +14,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
 
 public interface EventSpecification {
 
@@ -27,8 +30,8 @@ public interface EventSpecification {
 
     @Operation(summary = "모임 등록", description = "모임을 등록 합니다.")
     @ApiErrorCodeExamples(ErrorCode.NOT_FOUND_ERROR)
-    CommonResponse<Void> saveEvent(@RequestBody @Validated EventSaveRequestDto requestDto,
-                                   @AuthenticationPrincipal CustomUserDetails customUserDetails);
+    CommonResponse<Void> saveEvent(@ModelAttribute @Validated EventSaveRequestDto requestDto,
+                                   @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException;
 
     @Operation(summary = "모임 상세 조회", description = "모임의 상세 정보를 반환 합니다.")
     @ApiErrorCodeExample(ErrorCode.NOT_FOUND_ERROR)

--- a/src/main/java/lems/cowshed/config/aws/AwsS3Config.java
+++ b/src/main/java/lems/cowshed/config/aws/AwsS3Config.java
@@ -1,0 +1,31 @@
+package lems.cowshed.config.aws;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region).build();
+    }
+}

--- a/src/main/java/lems/cowshed/config/aws/AwsS3Util.java
+++ b/src/main/java/lems/cowshed/config/aws/AwsS3Util.java
@@ -1,0 +1,65 @@
+package lems.cowshed.config.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lems.cowshed.domain.UploadFile;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class AwsS3Util {
+    @Value("${spring.application.bucket.name}")
+    private String bucketName;
+    private final AmazonS3 s3Client;
+
+    public AwsS3Util(AmazonS3 s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    public List<UploadFile> uploadFiles(List<MultipartFile> multipartFiles) throws IOException {
+        if(multipartFiles.isEmpty()){
+            return null;
+        }
+
+        List<UploadFile> uploadFileList = new ArrayList<>();
+        for(MultipartFile multipartFile : multipartFiles){
+            uploadFileList.add(uploadFile(multipartFile));
+        }
+        return uploadFileList;
+    }
+
+    public UploadFile uploadFile(MultipartFile multipartFile) throws IOException {
+        if(multipartFile == null || multipartFile.isEmpty()){
+            return null;
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename();
+        String storeFileName = crateStoreFileName(originalFilename);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getInputStream().available());
+        s3Client.putObject(bucketName, storeFileName, multipartFile.getInputStream(), objectMetadata);
+
+        String accessUrl = s3Client.getUrl(bucketName, storeFileName).toString();
+        return new UploadFile(originalFilename,storeFileName, accessUrl);
+    }
+
+    private String crateStoreFileName(String originalFilename) {
+        String uuid = UUID.randomUUID().toString();
+        String ext = extractExt(originalFilename);
+        return uuid + "." + ext;
+    }
+
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(pos + 1);
+    }
+
+}

--- a/src/main/java/lems/cowshed/domain/UploadFile.java
+++ b/src/main/java/lems/cowshed/domain/UploadFile.java
@@ -1,0 +1,19 @@
+package lems.cowshed.domain;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class UploadFile {
+    private String uploadFileName;
+    private String storeFileName;
+    private String accessUrl;
+
+    public UploadFile() {
+    }
+
+    public UploadFile(String uploadFileName, String storeFileName, String accessUrl) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileName = storeFileName;
+        this.accessUrl = accessUrl;
+    }
+}

--- a/src/main/java/lems/cowshed/domain/event/Category.java
+++ b/src/main/java/lems/cowshed/domain/event/Category.java
@@ -3,7 +3,15 @@ package lems.cowshed.domain.event;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum Category {
-    SPORTS, TRAVEL, READING, MUSIC, PICTURE, FOOD, FASHION, BEAUTY;
+    SPORTS("운동"), TRAVEL("여행"), READING("독서"), RESTAURANT("맛집"),
+    PERFORMANCE("공연"), PICTURE("사진"), SELF_DEVELOPMENT("자기계발"), HOBBY("취미"),
+    PET("반려동물"),GAME("게임"),SERVICE("봉사"),REMAIN("기타");
+
+    private final String description;
+
+    Category(String description) {
+        this.description = description;
+    }
 
     @JsonCreator
     public static Category getEnumFromValue(String value){

--- a/src/main/java/lems/cowshed/domain/event/Event.java
+++ b/src/main/java/lems/cowshed/domain/event/Event.java
@@ -4,9 +4,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import lems.cowshed.api.controller.dto.event.request.EventUpdateRequestDto;
 import lems.cowshed.domain.BaseEntity;
+import lems.cowshed.domain.UploadFile;
 import lombok.*;
-
-import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,13 +34,18 @@ public class Event extends BaseEntity {
     @Column(name = "capacity")
     private int capacity;
 
+    @Embedded
+    private UploadFile uploadFile;
+
     @Builder
-    public Event(String name, Category category, String author, String content, int capacity) {
+    public Event(String name, Category category, String author, String content,
+                 int capacity, UploadFile uploadFile) {
         this.name = name;
         this.category = category;
         this.author = author;
         this.content = content;
         this.capacity = capacity;
+        this.uploadFile = uploadFile;
     }
 
     public void edit(EventUpdateRequestDto requestDto) {
@@ -58,5 +62,5 @@ public class Event extends BaseEntity {
     public boolean isNotSameAuthor(String author) {
         return !this.author.equals(author);
     }
-}
 
+}

--- a/src/main/java/lems/cowshed/domain/event/Event.java
+++ b/src/main/java/lems/cowshed/domain/event/Event.java
@@ -1,6 +1,7 @@
 package lems.cowshed.domain.event;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
 import lems.cowshed.api.controller.dto.event.request.EventUpdateRequestDto;
 import lems.cowshed.domain.BaseEntity;
 import lombok.*;
@@ -20,38 +21,25 @@ public class Event extends BaseEntity {
     @Column(name = "name", length = 20)
     private String name;
 
-    @Column(name = "event_date")
-    private LocalDate eventDate;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "category")
     private Category category;
 
-    @Column(name = "location", length = 20)
-    private String location;
-
     @Column(name = "author", length = 20)
     private String author;
-
-    @Column(name = "email",  length = 40)
-    private String email;
 
     @Column(name = "content", length = 200)
     private String content;
 
+    @Max(100)
     @Column(name = "capacity")
     private int capacity;
 
     @Builder
-    public Event(String name, LocalDate eventDate, Category category,
-                 String location, String author,
-                 String email, String content, int capacity) {
+    public Event(String name, Category category, String author, String content, int capacity) {
         this.name = name;
-        this.eventDate = eventDate;
         this.category = category;
-        this.location = location;
         this.author = author;
-        this.email = email;
         this.content = content;
         this.capacity = capacity;
     }
@@ -61,8 +49,6 @@ public class Event extends BaseEntity {
         this.capacity = requestDto.getCapacity();
         if(requestDto.getContent() != null) this.content = requestDto.getContent();
         if(requestDto.getCategory() != null) this.category = requestDto.getCategory();
-        if(requestDto.getEventDate() != null) this.eventDate = requestDto.getEventDate();
-        if(requestDto.getLocation() != null) this.location = requestDto.getLocation();
     }
 
     public boolean isOverCapacity(long capacity){

--- a/src/main/java/lems/cowshed/domain/event/query/BookmarkedEventSimpleInfoQuery.java
+++ b/src/main/java/lems/cowshed/domain/event/query/BookmarkedEventSimpleInfoQuery.java
@@ -21,9 +21,6 @@ public class BookmarkedEventSimpleInfoQuery implements EventIdProvider {
     @Schema(description = "모임 이름", example = "자전거 모임")
     private String name;
 
-    @Schema(description = "이벤트 날짜", example = "2024-10-19")
-    private LocalDate eventDate;
-
     @Schema(description = "주최자", example = "김철수")
     private String author;
 
@@ -43,12 +40,10 @@ public class BookmarkedEventSimpleInfoQuery implements EventIdProvider {
     private BookmarkStatus bookmarkStatus;
 
     @QueryProjection
-    public BookmarkedEventSimpleInfoQuery(Long id, String name, LocalDate eventDate,
-                                          String author, String content, int capacity,
+    public BookmarkedEventSimpleInfoQuery(Long id, String name, String author, String content, int capacity,
                                           LocalDateTime createdDateTime, BookmarkStatus bookmarkStatus) {
         this.id = id;
         this.name = name;
-        this.eventDate = eventDate;
         this.author = author;
         this.content = content;
         this.capacity = capacity;
@@ -57,12 +52,10 @@ public class BookmarkedEventSimpleInfoQuery implements EventIdProvider {
     }
 
     @Builder
-    public BookmarkedEventSimpleInfoQuery(Long id, String name, LocalDate eventDate,
-                                          String author, String content, Long applicants,
+    public BookmarkedEventSimpleInfoQuery(Long id, String name, String author, String content, Long applicants,
                                           int capacity, LocalDateTime createdDateTime, BookmarkStatus bookmarkStatus) {
         this.id = id;
         this.name = name;
-        this.eventDate = eventDate;
         this.author = author;
         this.content = content;
         this.applicants = applicants;
@@ -75,7 +68,6 @@ public class BookmarkedEventSimpleInfoQuery implements EventIdProvider {
         return BookmarkedEventSimpleInfoQuery.builder()
                 .id(event.getId())
                 .name(event.getName())
-                .eventDate(event.getEventDate())
                 .author(event.getAuthor())
                 .content(event.getContent())
                 .applicants(participantsCount)
@@ -89,7 +81,6 @@ public class BookmarkedEventSimpleInfoQuery implements EventIdProvider {
         return BookmarkedEventSimpleInfoQuery.builder()
                 .id(dto.getId())
                 .name(dto.getName())
-                .eventDate(dto.getEventDate())
                 .author(dto.getAuthor())
                 .content(dto.getContent())
                 .applicants(applicants)

--- a/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/query/EventQueryRepository.java
@@ -38,9 +38,7 @@ public class EventQueryRepository {
                         event.author,
                         event.category,
                         event.createdDateTime,
-                        event.location,
                         event.content,
-                        event.eventDate,
                         event.capacity,
                         userEvent.event.id.count(),
                         Expressions.stringTemplate("GROUP_CONCAT({0})", userEvent.user.id)
@@ -58,7 +56,6 @@ public class EventQueryRepository {
                 .select(new QParticipatingEventSimpleInfoQuery(
                         event.id,
                         event.name,
-                        event.eventDate,
                         event.author,
                         event.content,
                         userEvent.user.id.countDistinct().as("applicants"),
@@ -78,7 +75,6 @@ public class EventQueryRepository {
                 .select(new QBookmarkedEventSimpleInfoQuery(
                                 event.id,
                                 event.name,
-                                event.eventDate,
                                 event.author,
                                 event.content,
                                 event.capacity,
@@ -136,7 +132,6 @@ public class EventQueryRepository {
                         event.name,
                         event.author,
                         event.content,
-                        event.eventDate,
                         event.capacity,
                         event.createdDateTime,
                         bookmark.status

--- a/src/main/java/lems/cowshed/domain/event/query/ParticipatingEventSimpleInfoQuery.java
+++ b/src/main/java/lems/cowshed/domain/event/query/ParticipatingEventSimpleInfoQuery.java
@@ -22,9 +22,6 @@ public class ParticipatingEventSimpleInfoQuery implements EventIdProvider {
     @Schema(description = "모임 이름", example = "자전거 모임")
     private String name;
 
-    @Schema(description = "이벤트 날짜", example = "2024-10-19")
-    private LocalDate eventDate;
-
     @Schema(description = "주최자", example = "김철수")
     private String author;
 
@@ -44,13 +41,12 @@ public class ParticipatingEventSimpleInfoQuery implements EventIdProvider {
     private BookmarkStatus bookmarkStatus;
 
     @QueryProjection
-    public ParticipatingEventSimpleInfoQuery(Long id, String name, LocalDate eventDate, String author,
+    public ParticipatingEventSimpleInfoQuery(Long id, String name, String author,
                                              String content, Long applicants, int capacity,
                                              LocalDateTime createdDateTime) {
         this.id = id;
         this.author = author;
         this.name = name;
-        this.eventDate = eventDate;
         this.content = content;
         this.applicants = applicants;
         this.capacity = capacity;
@@ -58,12 +54,10 @@ public class ParticipatingEventSimpleInfoQuery implements EventIdProvider {
     }
 
     @Builder
-    private ParticipatingEventSimpleInfoQuery(Long id, String name, LocalDate eventDate,
-                                             String author, String content, Long applicants,
+    private ParticipatingEventSimpleInfoQuery(Long id, String name, String author, String content, Long applicants,
                                              int capacity, LocalDateTime createdDateTime, BookmarkStatus bookmarkStatus) {
         this.id = id;
         this.name = name;
-        this.eventDate = eventDate;
         this.author = author;
         this.content = content;
         this.applicants = applicants;
@@ -76,7 +70,6 @@ public class ParticipatingEventSimpleInfoQuery implements EventIdProvider {
         return ParticipatingEventSimpleInfoQuery.builder()
                 .id(query.getId())
                 .name(query.getName())
-                .eventDate(query.getEventDate())
                 .author(query.getAuthor())
                 .content(query.getContent())
                 .applicants(query.getApplicants())

--- a/src/test/java/lems/cowshed/api/controller/event/EventControllerTest.java
+++ b/src/test/java/lems/cowshed/api/controller/event/EventControllerTest.java
@@ -47,14 +47,14 @@ class EventControllerTest {
     @DisplayName("모임을 등록 합니다.")
     @Test
     void saveEvent() throws Exception {
-        //given
-        EventSaveRequestDto request = createEventSaveRequest("산책 모임", SPORTS, 20);
-
         //when //then
         mockMvc.perform(
                 post("/events")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("name", "산책 모임")
+                        .param("category", String.valueOf(SPORTS))
+                        .param("capacity", String.valueOf(20))
+                        .param("content", "테스트")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
                         .with(csrf())
                         .with(user(new CustomUserDetails(createForUserDetails())))
         )
@@ -63,22 +63,43 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.message").value("성공"));
     }
 
-    @DisplayName("모임을 등록 할때 최대 참가자는 200명을 초과 할수 없습니다.")
+    @DisplayName("모임을 등록 할때 최대 참가자는 100명 이다.")
     @Test
-    void saveEventWhenOverCapacity() throws Exception {
-        //given
-        EventSaveRequestDto request = createEventSaveRequest("산책 모임", SPORTS, 201);
-
+    void saveEvent_WhenOverCapacity() throws Exception {
         //when //then
         mockMvc.perform(
                         post("/events")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("name", "산책 모임")
+                                .param("category", String.valueOf(SPORTS))
+                                .param("capacity", String.valueOf(100))
+                                .param("content", "테스트")
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
                                 .with(csrf())
+                                .with(user(new CustomUserDetails(createForUserDetails())))
+
                 )
                 .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0].field").value("capacity"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("성공"));
+    }
+
+    @DisplayName("모임을 등록 할때 카테고리에 없는 값을 입력 한다면 예외가 발생 한다.")
+    @Test
+    void saveEvent_NotEnterCategory() throws Exception {
+        //when //then
+        mockMvc.perform(
+                        post("/events")
+                                .param("name", "산책 모임")
+                                .param("category", "sleeping")
+                                .param("capacity", String.valueOf(20))
+                                .param("content", "테스트")
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .with(csrf())
+                                .with(user(new CustomUserDetails(createForUserDetails())))
+
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @DisplayName("모임을 조회 한다.")
@@ -126,11 +147,9 @@ class EventControllerTest {
     private EventSaveRequestDto createEventSaveRequest(String name, Category category, int capacity) {
         return EventSaveRequestDto.builder()
                 .name(name)
-                .eventDate(LocalDate.of(2025,1,1))
                 .content("산책 하실분 모집 합니다.")
                 .category(category)
                 .capacity(capacity)
-                .location("한라산")
                 .build();
     }
 

--- a/src/test/java/lems/cowshed/api/controller/event/EventControllerTest.java
+++ b/src/test/java/lems/cowshed/api/controller/event/EventControllerTest.java
@@ -137,7 +137,6 @@ class EventControllerTest {
     private static Event createEvent(String author, String name, String content){
         return Event.builder()
                 .name(name)
-                .email("test@naver.com")
                 .author(author)
                 .content(content)
                 .build();

--- a/src/test/java/lems/cowshed/domain/event/EventRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/EventRepositoryTest.java
@@ -77,7 +77,6 @@ class EventRepositoryTest {
     private static Event createEvent(String author) {
         return Event.builder()
                 .name("자전거 모임")
-                .email("test@naver.com")
                 .author(author)
                 .build();
     }

--- a/src/test/java/lems/cowshed/service/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/EventServiceTest.java
@@ -141,8 +141,8 @@ class EventServiceTest {
 
         //then
         Event findEvent = eventRepository.findByName("자전거 모임");
-        assertThat(findEvent).extracting("name", "location", "capacity")
-                .containsExactly("자전거 모임", "서울", 10);
+        assertThat(findEvent).extracting("name", "capacity")
+                .containsExactly("자전거 모임", 10);
     }
 
     @DisplayName("모임을 조회 한다.")
@@ -540,7 +540,6 @@ class EventServiceTest {
     private static Event createEvent(String author, String name) {
         return Event.builder()
                 .name(name)
-                .email("test@naver.com")
                 .author(author)
                 .build();
     }
@@ -548,7 +547,6 @@ class EventServiceTest {
     private static Event createEvent(String author, String name, String content){
         return Event.builder()
                 .name(name)
-                .email("test@naver.com")
                 .author(author)
                 .content(content)
                 .build();
@@ -557,7 +555,6 @@ class EventServiceTest {
     private static Event createEvent(String author, String name, int capacity) {
         return Event.builder()
                 .name(name)
-                .email("test@naver.com")
                 .author(author)
                 .capacity(capacity)
                 .build();

--- a/src/test/java/lems/cowshed/service/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/EventServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
@@ -132,7 +133,7 @@ class EventServiceTest {
 
     @DisplayName("모임을 등록 한다.")
     @Test
-    void saveEvent() {
+    void saveEvent() throws IOException {
         //given
         EventSaveRequestDto request = createRequestDto("자전거 모임", "서울", 10);
 
@@ -143,6 +144,20 @@ class EventServiceTest {
         Event findEvent = eventRepository.findByName("자전거 모임");
         assertThat(findEvent).extracting("name", "capacity")
                 .containsExactly("자전거 모임", 10);
+    }
+
+    @DisplayName("모임을 등록할때 업로드 파일이 없다면 업로드 파일은 null이다.")
+    @Test
+    void saveEvent_whenNotRegisterFile_UploadFileIsNull() throws IOException {
+        //given
+        EventSaveRequestDto request = createRequestDto("자전거 모임", "서울", 10);
+
+        //when
+        eventService.saveEvent(request, "테스터");
+
+        //then
+        Event findEvent = eventRepository.findByName("자전거 모임");
+        assertThat(findEvent.getUploadFile()).isNull();
     }
 
     @DisplayName("모임을 조회 한다.")
@@ -563,7 +578,6 @@ class EventServiceTest {
     private EventSaveRequestDto createRequestDto(String name, String location, int capacity) {
         return EventSaveRequestDto.builder()
                 .name(name)
-                .location(location)
                 .capacity(capacity)
                 .build();
     }


### PR DESCRIPTION
##
### 🌱 작업 내용
[ 모임 필드 수정 ]
- 기존 : 모임에 참여
- 수정 : 모임 내부에 정기 모임을 만들어 정기모임에 참여
- 모임 날짜, 모임 담당 이메일, 모임 장소 제거

[ 모임 등록 변경 ]
- 필드 : 모임 이름,  카테고리, 내용, 정원, 대표 이미지 
- Aws S3 사용하여 이미지 등록

##
### ⏰ 기타 사항
[ 모임 정원 변경 (최대 인원) ]
- 기존 : 200명 
- 수정 : 100명 
