### PR TITLE
refactor: JWT 토큰 만료기간 30일 변경

### DIFF
--- a/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
@@ -67,7 +67,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(userId, username, email, role, 24 * 60 * 60 * 1000L);
+        String token = jwtUtil.createJwt(userId, username, email, role, 30 * 24 * 60 * 60 * 1000L);
 
         response.addHeader("Authorization", "Bearer " + token);
 


### PR DESCRIPTION
##
### 🌱 작업 내용
[ JWT 토큰 만료기간 30일 변경 ]
- 회원가입 이메일 인증으로 인한 테스트 어려움 때문에 JWT 만료기간 30일 변경