### PR TITLE
refactor: 모임 참여 코드 리팩토링

### DIFF
--- a/src/main/java/lems/cowshed/domain/event/EventRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/EventRepository.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Event> findPessimisticLockById(Long eventId);
+    Optional<Event> findEventWithLockById(Long eventId);
     Slice<Event> findEventsBy(Pageable pageable);
     Event findByName(String name);
     Optional<Event> findByIdAndAuthor(Long eventId, String author);

--- a/src/main/java/lems/cowshed/domain/event/participation/EventParticipantRepository.java
+++ b/src/main/java/lems/cowshed/domain/event/participation/EventParticipantRepository.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 public interface EventParticipantRepository extends JpaRepository<EventParticipant, Long> {
 
     @Query("SELECT COUNT(ep) From EventParticipant ep Where ep.event.id = :eventId")
-    long countParticipantByEventId(@Param("eventId") Long eventId);
+    long getParticipantCountById(@Param("eventId") Long eventId);
 
     List<EventParticipant> findEventParticipationByEventIdIn(List<Long> eventIds);
-    Optional<EventParticipant> findByEventIdAndUserId (Long EventId, Long userId);
+    Optional<EventParticipant> findByEventIdAndUserId (Long eventId, Long userId);
 }

--- a/src/main/java/lems/cowshed/exception/Message.java
+++ b/src/main/java/lems/cowshed/exception/Message.java
@@ -24,6 +24,7 @@ public enum Message {
     EVENT_NOT_REGISTERED_BY_USER("회원이 등록한 모임이 아닙니다."),
     EVENT_CAPACITY_OVER("참여 가능한 회원 수를 초과 하였습니다."),
 
-    USER_EVENT_NOT_FOUND("모임 참여 기록을 찾지 못했습니다.");
+    EVENT_PARTICIPATION_FOUND("모임 참여 기록을 찾지 못했습니다."),
+    EVENT_ALREADY_PARTICIPATION("모임에 이미 참여 중 입니다.");
     private final String message;
 }

--- a/src/main/java/lems/cowshed/exception/Reason.java
+++ b/src/main/java/lems/cowshed/exception/Reason.java
@@ -25,6 +25,6 @@ public enum Reason {
     EVENT_CAPACITY("event_capacity"),
     BusinessReason("Business"),
 
-    USER_EVENT("USER_EVENT");
+    EVENT_PARTICIPATION("USER_EVENT");
     private final String text;
 }


### PR DESCRIPTION
##
### 🌱 작업 내용
### [ 모임 참가 쿼리 이름 변경 ]
- findPessimisticLockById To findEventWithLockById
- 모임 조회 / 락 사용 명시
- countParticipantByEventId To getParticipantCountById
- 조회 대상 명시

### [ 모임 참가 코드 리팩 토링 ]
이전 코드 - 코드의 역할을 명확히 알기 어려움
<pre>
Event event = eventRepository.findPessimisticLockById(eventId).orElseThrow(() -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));

long participantsCount = eventParticipantRepository.countParticipantByEventId(event.getId());
if (isNotPossibleParticipateToEvent(event, participantsCount)) {
        throw new BusinessException(EVENT_CAPACITY, EVENT_CAPACITY_OVER);
}

User user = userRepository.findById(userId)
        .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));

EventParticipant eventParticipant = EventParticipant.of(user, event);
eventParticipantRepository.save(eventParticipant);
return eventParticipant.getId();
</pre>
변경 코드 - 메서드 분리
<pre>

##
### ⏰ 기타 사항
[ 모임 참가시 이미 참가 여부 체크 추가]
