### PR TITLE
feature: 모임 / 정기 모임 조회시 정기모임 등록자 체크 추가

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/dto/regular/event/RegularEventInfo.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/regular/event/RegularEventInfo.java
@@ -15,10 +15,11 @@ public class RegularEventInfo {
     private int capacity;
     private int applicants;
     private boolean isParticipated;
+    private boolean isRegularRegistrant;
 
     @Builder
     private RegularEventInfo(long id, String name, String location, LocalDateTime dateTime,
-                             int capacity, int applicants, boolean isParticipated) {
+                             int capacity, int applicants, boolean isParticipated, boolean isRegularRegistrant) {
         this.id = id;
         this.name = name;
         this.location = location;
@@ -26,9 +27,11 @@ public class RegularEventInfo {
         this.capacity = capacity;
         this.applicants = applicants;
         this.isParticipated = isParticipated;
+        this.isRegularRegistrant = isRegularRegistrant;
     }
 
-    public static RegularEventInfo of(RegularEvent regularEvent, int applicants, boolean isParticipated){
+    public static RegularEventInfo of(RegularEvent regularEvent, int applicants, boolean isParticipated,
+                                        boolean isRegularRegistrant){
         return RegularEventInfo.builder()
                 .id(regularEvent.getId())
                 .name(regularEvent.getName())
@@ -37,6 +40,7 @@ public class RegularEventInfo {
                 .capacity(regularEvent.getCapacity())
                 .applicants(applicants)
                 .isParticipated(isParticipated)
+                .isRegularRegistrant((isRegularRegistrant))
                 .build();
     }
 

--- a/src/main/java/lems/cowshed/api/controller/dto/regular/event/RegularEventSaveRequest.java
+++ b/src/main/java/lems/cowshed/api/controller/dto/regular/event/RegularEventSaveRequest.java
@@ -33,13 +33,14 @@ public class RegularEventSaveRequest {
         this.capacity = capacity;
     }
 
-    public RegularEvent toEntity(Event event) {
+    public RegularEvent toEntity(Event event, Long userId) {
         return RegularEvent.builder()
                 .name(name)
                 .dateTime(dateTime)
                 .location(location)
                 .capacity(capacity)
                 .event(event)
+                .userId(userId)
                 .build();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/regular/event/RegularEventController.java
+++ b/src/main/java/lems/cowshed/api/controller/regular/event/RegularEventController.java
@@ -3,8 +3,10 @@ package lems.cowshed.api.controller.regular.event;
 import jakarta.validation.Valid;
 import lems.cowshed.api.controller.CommonResponse;
 import lems.cowshed.api.controller.dto.regular.event.RegularEventSaveRequest;
+import lems.cowshed.domain.user.CustomUserDetails;
 import lems.cowshed.service.RegularEventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/events/{event-id}/regular")
@@ -16,8 +18,9 @@ public class RegularEventController implements RegularEventSpecification {
 
     @PostMapping
     public CommonResponse<Void> save(@Valid @RequestBody RegularEventSaveRequest request,
-                                     @PathVariable("event-id") Long eventId) {
-        regularEventService.save(request, eventId);
+                                     @PathVariable("event-id") Long eventId,
+                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
+        regularEventService.save(request, eventId, userDetails.getUserId());
         return CommonResponse.success();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/regular/event/RegularEventSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/regular/event/RegularEventSpecification.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lems.cowshed.api.controller.CommonResponse;
 import lems.cowshed.api.controller.dto.regular.event.RegularEventSaveRequest;
+import lems.cowshed.domain.user.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -13,5 +15,6 @@ public interface RegularEventSpecification {
 
     @Operation(summary = "정기 모임 등록", description = "정기 모임을 등록 합니다.")
     CommonResponse<Void> save(@Valid @RequestBody RegularEventSaveRequest request,
-                              @PathVariable("event-id") Long eventId);
+                              @PathVariable("event-id") Long eventId,
+                              @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/lems/cowshed/api/controller/regular/event/participation/RegularEventParticipationController.java
+++ b/src/main/java/lems/cowshed/api/controller/regular/event/participation/RegularEventParticipationController.java
@@ -5,22 +5,26 @@ import lems.cowshed.domain.user.CustomUserDetails;
 import lems.cowshed.service.RegularEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/regular/{regular-id}/participation")
+@RequestMapping("/regular")
 @RequiredArgsConstructor
 @RestController
 public class RegularEventParticipationController implements RegularEventParticipationSpecification {
 
     private final RegularEventService regularEventService;
 
-    @PostMapping
+    @PostMapping("/{regular-id}/participation")
     public CommonResponse<Void> save(@PathVariable("regular-id") Long regularId,
                                      @AuthenticationPrincipal CustomUserDetails userDetails){
         regularEventService.saveParticipation(regularId,userDetails.getUserId());
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/participation/{participation-id}")
+    public CommonResponse<Void> delete(@PathVariable("participation-id") Long participationId,
+                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
+        regularEventService.deleteParticipation(participationId, userDetails.getUserId());
         return CommonResponse.success();
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/regular/event/participation/RegularEventParticipationSpecification.java
+++ b/src/main/java/lems/cowshed/api/controller/regular/event/participation/RegularEventParticipationSpecification.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface RegularEventParticipationSpecification {
 
     @Operation(summary = "정기 모임 참여", description = "정기 모임에 참여 합니다.")
-    CommonResponse<Void> save(@PathVariable("event-id") Long eventId, @AuthenticationPrincipal CustomUserDetails userDetails);
+    CommonResponse<Void> save(@PathVariable("regular-id") Long regularId, @AuthenticationPrincipal CustomUserDetails userDetails);
 
+    @Operation(summary = "정기 모임 참여 해제", description = "정기 모임에 참여를 해제 합니다.")
+    CommonResponse<Void> delete(@PathVariable("regular-id") Long regularId, @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/lems/cowshed/domain/regular/event/RegularEvent.java
+++ b/src/main/java/lems/cowshed/domain/regular/event/RegularEvent.java
@@ -23,6 +23,7 @@ public class RegularEvent extends BaseEntity {
     private LocalDateTime dateTime;
     private String location;
     private int capacity;
+    private Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
@@ -32,22 +33,25 @@ public class RegularEvent extends BaseEntity {
     private List<RegularEventParticipation> participations = new ArrayList<>();
 
     @Builder
-    private RegularEvent(String name, LocalDateTime dateTime, String location, int capacity, Event event) {
+    private RegularEvent(String name, LocalDateTime dateTime, String location,
+                         int capacity, Event event, Long userId) {
         this.name = name;
         this.dateTime = dateTime;
         this.location = location;
         this.capacity = capacity;
         this.event = event;
+        this.userId = userId;
     }
 
     public static RegularEvent of(String name, LocalDateTime dateTime, String location,
-                                  int capacity, Event event){
+                                  int capacity, Long userId, Event event){
         return RegularEvent.builder()
                 .name(name)
                 .dateTime(dateTime)
                 .location(location)
                 .capacity(capacity)
                 .event(event)
+                .userId(userId)
                 .build();
     }
 

--- a/src/main/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipationRepository.java
+++ b/src/main/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipationRepository.java
@@ -1,6 +1,13 @@
 package lems.cowshed.domain.regular.event.participation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RegularEventParticipationRepository extends JpaRepository<RegularEventParticipation, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from RegularEventParticipation rep where rep.id = :participationId And rep.userId = :userId")
+    int deleteByIdAndUserId(@Param("participationId") Long participationId, @Param("userId") Long userId);
 }

--- a/src/main/java/lems/cowshed/service/RegularEventService.java
+++ b/src/main/java/lems/cowshed/service/RegularEventService.java
@@ -29,11 +29,11 @@ public class RegularEventService {
     private final RegularEventRepository regularEventRepository;
     private final RegularEventParticipationRepository regularEventParticipationRepository;
 
-    public void save(RegularEventSaveRequest request, Long eventId) {
+    public void save(RegularEventSaveRequest request, Long eventId, Long userId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));
 
-        RegularEvent regularEvent = request.toEntity(event);
+        RegularEvent regularEvent = request.toEntity(event, userId);
         regularEventRepository.save(regularEvent);
     }
 
@@ -43,6 +43,11 @@ public class RegularEventService {
         regularEventParticipation(regularEvent);
 
         regularEventParticipationRepository.save(RegularEventParticipation.of(user, regularEvent));
+    }
+
+    public void deleteParticipation(Long participationId, Long userId) {
+        findUser(userId);
+        regularEventParticipationRepository.deleteByIdAndUserId(participationId, userId);
     }
 
     private User findUser(Long userId) {

--- a/src/main/java/lems/cowshed/service/event/EventService.java
+++ b/src/main/java/lems/cowshed/service/event/EventService.java
@@ -220,11 +220,15 @@ public class EventService {
                 .toList();
     }
 
-    private List<RegularEventInfo> convertRegularEventInfo(List<RegularEvent> uniqueRegularEvents, Map<Long, Integer> participantCountMap, Long userId) {
+    private List<RegularEventInfo> convertRegularEventInfo(List<RegularEvent> uniqueRegularEvents,
+                                                           Map<Long, Integer> participantCountMap, Long userId) {
         return uniqueRegularEvents.stream()
                 .map(re ->
-                        RegularEventInfo.of(re, participantCountMap.get(re.getId()),
-                                re.getParticipations().stream().anyMatch(p -> p.getUserId().equals(userId)))
+                        RegularEventInfo.of(re,
+                                participantCountMap.get(re.getId()),
+                                re.getParticipations().stream()
+                                        .anyMatch(p -> p.getUserId().equals(userId)),
+                                re.getUserId().equals(userId))
                 )
                 .toList();
     }

--- a/src/test/java/lems/cowshed/api/controller/regular/event/RegularEventControllerTest.java
+++ b/src/test/java/lems/cowshed/api/controller/regular/event/RegularEventControllerTest.java
@@ -1,7 +1,10 @@
-package lems.cowshed.api.controller.recurring.event;
+package lems.cowshed.api.controller.regular.event;
 
 import lems.cowshed.ControllerTestSupport;
 import lems.cowshed.api.controller.dto.regular.event.RegularEventSaveRequest;
+import lems.cowshed.domain.user.CustomUserDetails;
+import lems.cowshed.domain.user.Role;
+import lems.cowshed.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -9,6 +12,7 @@ import org.springframework.http.MediaType;
 import java.time.LocalDateTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,6 +30,7 @@ class RegularEventControllerTest extends ControllerTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                         .with(csrf())
+                        .with(user(new CustomUserDetails(createForUserDetails())))
         )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("성공"));
@@ -94,6 +99,7 @@ class RegularEventControllerTest extends ControllerTestSupport {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                                 .with(csrf())
+                                .with(user(new CustomUserDetails(createForUserDetails())))
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("성공"));
@@ -129,5 +135,10 @@ class RegularEventControllerTest extends ControllerTestSupport {
                 .location("테스트 장소")
                 .capacity(50)
                 .build();
+    }
+
+    private User createForUserDetails(){
+        return User.createUserForDetails(1L, "test",
+                "password", Role.ROLE_USER,"testEmail");
     }
 }

--- a/src/test/java/lems/cowshed/service/RegularEventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/RegularEventServiceTest.java
@@ -1,11 +1,16 @@
 package lems.cowshed.service;
 
+import jakarta.persistence.EntityManager;
 import lems.cowshed.IntegrationTestSupport;
 import lems.cowshed.api.controller.dto.regular.event.RegularEventSaveRequest;
 import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.event.EventRepository;
 import lems.cowshed.domain.regular.event.RegularEvent;
 import lems.cowshed.domain.regular.event.RegularEventRepository;
+import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
+import lems.cowshed.domain.regular.event.participation.RegularEventParticipationRepository;
+import lems.cowshed.domain.user.User;
+import lems.cowshed.domain.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +29,16 @@ class RegularEventServiceTest extends IntegrationTestSupport {
     private EventRepository eventRepository;
 
     @Autowired
-    private RegularEventRepository repository;
+    private RegularEventRepository regularEventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RegularEventParticipationRepository participationRepository;
 
     @DisplayName("정기 모임을 등록 한다.")
     @Test
@@ -41,18 +55,57 @@ class RegularEventServiceTest extends IntegrationTestSupport {
                 .build();
 
         //when
-        regularEventService.save(request, event.getId());
+        regularEventService.save(request, event.getId(), null);
 
         //then
-        List<RegularEvent> savedEvents = repository.findAll();
+        List<RegularEvent> savedEvents = regularEventRepository.findAll();
         assertThat(savedEvents).hasSize(1);
         assertThat(savedEvents.get(0).getName()).isEqualTo("정기 모임");
     }
 
-    private static Event createEvent(String author, String name) {
+    @DisplayName("정기 모임 참석을 해제 한다.")
+    @Test
+    void deleteByParticipationIdAndUserId() {
+        //given
+        User user = createUser("정기 모임 생성자", "RegularEventCreator");
+        userRepository.save(user);
+
+        Event event = createEvent("테스터", "테스트 모임");
+        eventRepository.save(event);
+
+        RegularEvent regularEvent = createRegularEvent(user);
+        regularEventRepository.save(regularEvent);
+
+        RegularEventParticipation participation = RegularEventParticipation.of(user, regularEvent);
+        participationRepository.save(participation);
+
+        //when
+        regularEventService.deleteParticipation(participation.getId(), user.getId());
+
+        //then
+        assertThat(participationRepository.findById(participation.getId())).isEmpty();
+    }
+
+    private Event createEvent(String author, String name) {
         return Event.builder()
                 .name(name)
                 .author(author)
+                .build();
+    }
+
+    private RegularEvent createRegularEvent(User user){
+        return RegularEvent.builder()
+                .name("정기 모임")
+                .dateTime(LocalDateTime.of(2025, 5, 2,12 ,0,0))
+                .location("테스트 장소")
+                .capacity(50)
+                .userId(user.getId())
+                .build();
+    }
+    private User createUser(String username, String email) {
+        return User.builder()
+                .username(username)
+                .email(email)
                 .build();
     }
 }


### PR DESCRIPTION
##
### 🌱 작업 내용
### [ 정기 모임 등록자 체크 추가 ]
- 정기 모임 만든 회원을 식별 하기 위해 정기 모임 등록시 userId 추가
- 모임 / 정기 모임 조회시 정기 모임 등록한 회원인지 여부 추가
- 테스트 여부 : O

### [ 정기 모임 참석 해제 추가 ]
- 테스트 여부 : O

