### PR TITLE
Refactor: 모임 / 모임 참가 연관 관계 제거

### DIFF
--- a/src/main/java/lems/cowshed/domain/event/Event.java
+++ b/src/main/java/lems/cowshed/domain/event/Event.java
@@ -5,15 +5,17 @@ import jakarta.validation.constraints.Max;
 import lems.cowshed.domain.BaseEntity;
 import lems.cowshed.domain.UploadFile;
 import lems.cowshed.domain.bookmark.Bookmark;
-import lems.cowshed.domain.event.participation.EventParticipation;
 import lems.cowshed.global.exception.BusinessException;
-
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import static lems.cowshed.global.exception.Message.*;
-import static lems.cowshed.global.exception.Reason.*;
+
+import static lems.cowshed.global.exception.Message.EVENT_INVALID_UPDATE_CAPACITY;
+import static lems.cowshed.global.exception.Reason.EVENT_PARTICIPATION;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,32 +23,26 @@ import static lems.cowshed.global.exception.Reason.*;
 public class Event extends BaseEntity {
 
     @Id
-    @Column(name = "event_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", length = 20)
     private String name;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category")
     private Category category;
 
-    @Column(name = "author", length = 20)
     private String author;
 
-    @Column(name = "content", length = 200)
     private String content;
 
     @Max(100)
-    @Column(name = "capacity")
     private int capacity;
 
     @Embedded
     private UploadFile uploadFile;
 
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<EventParticipation> participants = new ArrayList<>();
+    @Version
+    private long version;
 
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Bookmark> bookmarks = new ArrayList<>();
@@ -69,19 +65,19 @@ public class Event extends BaseEntity {
         this.content = content;
         updateCapacity(participantsCount, capacity);
 
-        if(uploadFile != null){
+        if (uploadFile != null) {
             this.updateUploadFile(uploadFile);
         }
     }
 
     public void updateCapacity(long participantsCount, int updateCapacity) {
-        if(participantsCount > updateCapacity){
+        if (participantsCount > updateCapacity) {
             throw new BusinessException(EVENT_PARTICIPATION, EVENT_INVALID_UPDATE_CAPACITY);
         }
         this.capacity = updateCapacity;
     }
 
-    public boolean isOverCapacity(long capacity){
+    public boolean isOverCapacity(long capacity) {
         return this.capacity <= capacity;
     }
 

--- a/src/main/java/lems/cowshed/domain/event/participation/EventParticipation.java
+++ b/src/main/java/lems/cowshed/domain/event/participation/EventParticipation.java
@@ -2,44 +2,38 @@ package lems.cowshed.domain.event.participation;
 
 import jakarta.persistence.*;
 import lems.cowshed.domain.BaseEntity;
-import lems.cowshed.domain.event.Event;
 import lems.cowshed.domain.user.User;
 import lombok.Getter;
 
-import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.FetchType.LAZY;
 
 @Getter
 @Entity
 public class EventParticipation extends BaseEntity {
 
     @Id
-    @Column(name = "event_participation_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
+    private long eventId;
 
-    protected EventParticipation() {}
+    protected EventParticipation() {
+    }
 
-    public void connectUser(User user){
+    public EventParticipation(long eventId) {
+        this.eventId = eventId;
+    }
+
+    public void connectUser(User user) {
         this.user = user;
     }
 
-    public void connectEvent(Event event){
-        this.event = event;
-        event.getParticipants().add(this);
-    }
-
-    public static EventParticipation of(User user, Event event){
-        EventParticipation participation = new EventParticipation();
+    public static EventParticipation of(User user, long eventId) {
+        EventParticipation participation = new EventParticipation(eventId);
         participation.connectUser(user);
-        participation.connectEvent(event);
         return participation;
     }
 }

--- a/src/main/java/lems/cowshed/domain/event/participation/Participants.java
+++ b/src/main/java/lems/cowshed/domain/event/participation/Participants.java
@@ -20,8 +20,8 @@ public class Participants {
         return participants.stream()
                 .collect(
                         Collectors.groupingBy(
-                                userEvent -> userEvent.getEvent().getId()
-                                , Collectors.counting()
+                                EventParticipation::getEventId,
+                                Collectors.counting()
                         ));
     }
 }

--- a/src/main/java/lems/cowshed/dto/event/response/EventInfo.java
+++ b/src/main/java/lems/cowshed/dto/event/response/EventInfo.java
@@ -43,7 +43,7 @@ public class EventInfo {
         this.accessUrl = accessUrl;
     }
 
-    public static EventInfo of(Event event) {
+    public static EventInfo of(Event event, int participantCount) {
         String accessUrl = getAccessUrl(event);
 
         return EventInfo.builder()
@@ -53,7 +53,7 @@ public class EventInfo {
                 .accessUrl(accessUrl)
                 .content(event.getContent())
                 .capacity(event.getCapacity())
-                .applicants(event.getParticipants().size())
+                .applicants(participantCount)
                 .build();
     }
 

--- a/src/main/java/lems/cowshed/dto/event/response/EventWithRegularInfo.java
+++ b/src/main/java/lems/cowshed/dto/event/response/EventWithRegularInfo.java
@@ -1,11 +1,12 @@
 package lems.cowshed.dto.event.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lems.cowshed.domain.regular.event.RegularEvent;
-import lems.cowshed.dto.regular.event.response.RegularEventInfo;
 import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lems.cowshed.domain.event.Category;
 import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.participation.EventParticipation;
+import lems.cowshed.domain.regular.event.RegularEvent;
+import lems.cowshed.dto.regular.event.response.RegularEventInfo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,34 +15,34 @@ import java.util.List;
 @Getter
 @Schema(description = "모임/ 정기모임 상세")
 public class EventWithRegularInfo {
-    
+
     @Schema(description = "모임 id", example = "1")
     Long eventId;
-    
+
     @Schema(description = "모임 이름", example = "농구 모임")
     String name;
-    
+
     @Schema(description = "카테고리", example = "스포츠")
     Category category;
-    
+
     @Schema(description = "내용", example = "같이 운동하실 분 구합니다. 같이 프레스 운동 하면서 서로 보조해주실 분 구합니다.")
     String content;
-    
+
     @Schema(description = "수용 인원", example = "100")
     int capacity;
-    
+
     @Schema(description = "참여 신청 인원", example = "50")
     long applicants;
-    
+
     @Schema(description = "북마크 여부", example = "BOOKMARK")
     BookmarkStatus bookmarkStatus;
-    
+
     @Schema(description = "모임 대표 이미지 주소", example = "URL 주소")
     private String accessUrl;
-    
+
     @Schema(description = "내가 등록한 모임 인지 여부", example = "true")
     boolean isEventRegistrant;
-    
+
     @Schema(description = "내가 참여한 모임 인지 여부", example = "true")
     boolean isParticipated;
 
@@ -66,10 +67,11 @@ public class EventWithRegularInfo {
         this.regularEvents = regularEvents;
     }
 
-    public static EventWithRegularInfo of(Event event, List<RegularEvent> regularEvents, Long userId,
+    public static EventWithRegularInfo of(Event event, List<EventParticipation> participants,
+                                          List<RegularEvent> regularEvents, Long userId,
                                           String username, BookmarkStatus bookmarkStatus) {
 
-        boolean isParticipated = isEventParticipatedUser(event, userId);
+        boolean isParticipated = isEventParticipatedUser(participants, userId);
         List<RegularEventInfo> regularEventsInfo = convertToResponses(regularEvents, userId);
         String accessUrl = getAccessUrl(event);
 
@@ -80,7 +82,7 @@ public class EventWithRegularInfo {
                 .accessUrl(accessUrl)
                 .content(event.getContent())
                 .capacity(event.getCapacity())
-                .applicants(event.getParticipants().size())
+                .applicants(participants.size())
                 .bookmarkStatus(bookmarkStatus)
                 .isEventRegistrant(event.getAuthor().equals(username))
                 .isParticipated(isParticipated)
@@ -98,8 +100,8 @@ public class EventWithRegularInfo {
                 .toList();
     }
 
-    private static boolean isEventParticipatedUser(Event event, Long userId) {
-        List<Long> participantsUserIds = event.getParticipants().stream()
+    private static boolean isEventParticipatedUser(List<EventParticipation> participants, Long userId) {
+        List<Long> participantsUserIds = participants.stream()
                 .map(participant -> participant.getUser().getId())
                 .toList();
 

--- a/src/main/java/lems/cowshed/dto/regular/event/response/RegularEventSearchResponse.java
+++ b/src/main/java/lems/cowshed/dto/regular/event/response/RegularEventSearchResponse.java
@@ -5,6 +5,7 @@ import lems.cowshed.domain.event.participation.EventParticipation;
 import lems.cowshed.domain.regular.event.RegularEvent;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +36,7 @@ public class RegularEventSearchResponse {
                         RegularEventSearchInfo.of(
                                 regularEvent,
                                 regularIdParticipantMap.get(regularEvent.getId()),
-                                eventIdParticipantUserIdsMap.get(regularEvent.getEvent().getId()).contains(userId))
+                                eventIdParticipantUserIdsMap.getOrDefault(regularEvent.getEvent().getId(), Collections.emptySet()).contains(userId))
                 )
                 .toList();
 

--- a/src/main/java/lems/cowshed/dto/user/mypage/MyPageBookmarkedEventsInfo.java
+++ b/src/main/java/lems/cowshed/dto/user/mypage/MyPageBookmarkedEventsInfo.java
@@ -1,10 +1,13 @@
 package lems.cowshed.dto.user.mypage;
 
 import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.participation.EventParticipation;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 public class MyPageBookmarkedEventsInfo {
@@ -17,9 +20,13 @@ public class MyPageBookmarkedEventsInfo {
         this.hasNext = hasNext;
     }
 
-    public static MyPageBookmarkedEventsInfo of(List<Event> events, boolean hasNext){
+    public static MyPageBookmarkedEventsInfo of(List<Event> events,
+                                                Map<Long, List<EventParticipation>> groupedEventIdMap, boolean hasNext) {
         List<ParticipatedEventsInfo> participatedEventsInfos = events.stream()
-                .map(event -> ParticipatedEventsInfo.of(event, event.getParticipants().size()))
+                .map(event -> {
+                    List<EventParticipation> participants = groupedEventIdMap.getOrDefault(event.getId(), Collections.emptyList());
+                    return ParticipatedEventsInfo.of(event, participants.size());
+                })
                 .toList();
 
         return new MyPageBookmarkedEventsInfo(participatedEventsInfos, hasNext);
@@ -36,16 +43,16 @@ public class MyPageBookmarkedEventsInfo {
         private int applicantCount;
 
         @Builder
-        private ParticipatedEventsInfo(Event event, int applicantCount){
+        private ParticipatedEventsInfo(Event event, int applicantCount) {
             this.eventId = event.getId();
             this.name = event.getName();
             this.category = event.getCategory().getDescription();
-            this.content = event.getContent().length() > 30 ? event.getContent().substring(0,30) : event.getContent();
+            this.content = event.getContent().length() > 30 ? event.getContent().substring(0, 30) : event.getContent();
             this.accessUrl = event.getUploadFile() != null ? event.getUploadFile().getAccessUrl() : null;
             this.applicantCount = applicantCount;
         }
 
-        private static ParticipatedEventsInfo of(Event event, int applicantCount){
+        private static ParticipatedEventsInfo of(Event event, int applicantCount) {
             return ParticipatedEventsInfo.builder()
                     .event(event)
                     .applicantCount(applicantCount)

--- a/src/main/java/lems/cowshed/dto/user/mypage/MyPageParticipatedEventsInfo.java
+++ b/src/main/java/lems/cowshed/dto/user/mypage/MyPageParticipatedEventsInfo.java
@@ -1,10 +1,13 @@
 package lems.cowshed.dto.user.mypage;
 
 import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.participation.EventParticipation;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 public class MyPageParticipatedEventsInfo {
@@ -18,13 +21,14 @@ public class MyPageParticipatedEventsInfo {
         this.hasNext = hasNext;
     }
 
-    public static MyPageParticipatedEventsInfo fromEvents(List<Event> events, boolean hasNext) {
+    public static MyPageParticipatedEventsInfo fromEvents(List<Event> events,
+                                                          Map<Long, List<EventParticipation>> groupedByEventIdMap, boolean hasNext) {
+
         List<MyParticipatedEventsInfo> result = events.stream()
-                .map(event -> MyParticipatedEventsInfo.of(
-                        event,
-                        event.getParticipants().size()
-                ))
-                .toList();
+                .map(event -> {
+                    List<EventParticipation> participants = groupedByEventIdMap.getOrDefault(event.getId(), Collections.emptyList());
+                    return MyParticipatedEventsInfo.of(event, participants.size());}
+                ).toList();
 
         return new MyPageParticipatedEventsInfo(result, hasNext);
     }

--- a/src/main/java/lems/cowshed/repository/event/EventRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/EventRepository.java
@@ -16,22 +16,19 @@ import java.util.Set;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Event> findPessimisticById(Long eventId);
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    Optional<Event> finByIdWithOptimisticLock(Long eventId);
 
     Slice<Event> findEventsBy(Pageable pageable);
     Event findByName(String name);
-
-    @Query("select distinct e from Event e left join fetch e.participants where e.id = :eventId and e.author = :author")
-    Optional<Event> findByIdAndAuthorFetchParticipation(@Param("eventId") Long eventId, @Param("author") String author);
 
     Optional<Event> findByIdAndAuthor(Long eventId, String author);
 
     @Query("SELECT b.event.id FROM Bookmark b WHERE b.userId = :userId AND b.event.id IN :eventIds AND b.status = :bookmarkStatus")
     Set<Long> findEventIdsBookmarkedByUser(@Param("userId") Long userId, @Param("eventIds") List<Long> eventIds, @Param("bookmarkStatus") BookmarkStatus bookmarkStatus);
 
-    @Query("select distinct e from Event e left join fetch e.participants ep where e.id In :eventIds order by e.id desc")
-    List<Event> findByIdInFetchParticipation(List<Long> eventIds);
+    @Query("select e from Event e left join e.participants ep where e.id In :eventIds order by e.id desc")
+    List<Event> findByIdIn(List<Long> eventIds);
 
     @Query("select distinct e from Event e left join fetch e.bookmarks b where e.id In :eventIds")
     List<Event> findByIdInFetchBookmarks(List<Long> eventIds);

--- a/src/main/java/lems/cowshed/repository/event/EventRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/EventRepository.java
@@ -17,7 +17,8 @@ import java.util.Set;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
-    Optional<Event> finByIdWithOptimisticLock(Long eventId);
+    @Query("select e from Event e where e.id = :eventId")
+    Optional<Event> finByIdWithOptimisticLock(@Param("eventId") Long eventId);
 
     Slice<Event> findEventsBy(Pageable pageable);
     Event findByName(String name);
@@ -27,8 +28,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT b.event.id FROM Bookmark b WHERE b.userId = :userId AND b.event.id IN :eventIds AND b.status = :bookmarkStatus")
     Set<Long> findEventIdsBookmarkedByUser(@Param("userId") Long userId, @Param("eventIds") List<Long> eventIds, @Param("bookmarkStatus") BookmarkStatus bookmarkStatus);
 
-    @Query("select e from Event e left join e.participants ep where e.id In :eventIds order by e.id desc")
-    List<Event> findByIdIn(List<Long> eventIds);
+    @Query("select e from Event e left join EventParticipation ep on e.id = ep.eventId where e.id In :eventIds order by e.id desc")
+    List<Event> findByIdIn(@Param("eventIds") List<Long> eventIds);
 
     @Query("select distinct e from Event e left join fetch e.bookmarks b where e.id In :eventIds")
     List<Event> findByIdInFetchBookmarks(List<Long> eventIds);

--- a/src/main/java/lems/cowshed/repository/event/participation/EventParticipantRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/participation/EventParticipantRepository.java
@@ -10,14 +10,19 @@ import java.util.Optional;
 
 public interface EventParticipantRepository extends JpaRepository<EventParticipation, Long> {
 
-    @Query("SELECT COUNT(ep) From EventParticipation ep Where ep.event.id = :eventId")
+    @Query("SELECT COUNT(ep) From EventParticipation ep Where ep.eventId = :eventId")
     long getParticipationCountById(@Param("eventId") Long eventId);
 
     List<EventParticipation> findEventParticipationByEventIdIn(List<Long> eventIds);
 
     Optional<EventParticipation> findByEventIdAndUserId(Long eventId, Long userId);
 
+    @Query("select ep from EventParticipation ep where ep.eventId in :eventId")
+    List<EventParticipation> findByEventId(@Param("eventId") Long eventId);
+
+    @Query("select ep from EventParticipation ep where ep.eventId in :eventIds")
+    List<EventParticipation> findByEventIdIn(@Param("eventIds") List<Long> eventIds);
+
     @Query("SELECT count(ep) from EventParticipation ep where ep.user.id = :userId")
     long findCountByUserId(@Param("userId") Long userId);
-
 }

--- a/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
@@ -163,13 +163,6 @@ public class EventQueryRepository {
         return count.intValue();
     }
 
-    public List<Event> findEventFetchParticipantsIn(List<Long> eventIds) {
-        return queryFactory.selectFrom(event)
-                .leftJoin(event.participants, eventParticipation).fetchJoin()
-                .where(event.id.in(eventIds))
-                .fetch();
-    }
-
     private BooleanBuilder categoryIn(Category category) {
         return nullSafeBuilder(() -> event.category.in(category));
     }

--- a/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
@@ -48,17 +48,8 @@ public class EventQueryRepository {
                 ))
                 .from(eventParticipation)
                 .join(eventParticipation.user, user)
-                .on(eventParticipation.event.id.eq(eventId))
+                .on(eventParticipation.eventId.eq(eventId))
                 .fetch();
-    }
-
-    public Event findEventFetchParticipants(Long eventId){
-        return queryFactory
-                .select(event)
-                .from(event)
-                .leftJoin(event.participants, eventParticipation).fetchJoin()
-                .where(event.id.eq(eventId))
-                .fetchOne();
     }
 
     public List<RegularEvent> findRegularEventsFetchParticipants(Long eventId) {
@@ -84,8 +75,8 @@ public class EventQueryRepository {
                         event.createdDateTime
                 ))
                 .from(eventParticipation)
-                .rightJoin(eventParticipation.event, event)
-                .where(eventParticipation.event.id.in(eventIds))
+                .rightJoin(event).on(eventParticipation.eventId.eq(event.id))
+                .where(eventParticipation.eventId.in(eventIds))
                 .groupBy(event.id)
                 .fetch();
     }
@@ -133,16 +124,16 @@ public class EventQueryRepository {
     }
 
     public Map<Long,Long> findEventParticipantCountByEventIds(List<Long> eventIds) {
-        List<Tuple> tuples = queryFactory.select(eventParticipation.event.id, eventParticipation.event.id.count())
+        List<Tuple> tuples = queryFactory.select(eventParticipation.eventId, eventParticipation.eventId.count())
                 .from(eventParticipation)
-                .where(eventParticipation.event.id.in(eventIds))
-                .groupBy(eventParticipation.event.id)
+                .where(eventParticipation.eventId.in(eventIds))
+                .groupBy(eventParticipation.eventId)
                 .fetch();
 
         return tuples.stream()
                 .collect(Collectors.toMap(
-                        tuple -> tuple.get(eventParticipation.event.id),
-                        tuple -> Optional.ofNullable(tuple.get(eventParticipation.event.id.count())).orElse(0L)
+                        tuple -> tuple.get(eventParticipation.eventId),
+                        tuple -> Optional.ofNullable(tuple.get(eventParticipation.eventId.count())).orElse(0L)
                 ));
     }
 

--- a/src/main/java/lems/cowshed/repository/user/query/UserMyPageQueryRepository.java
+++ b/src/main/java/lems/cowshed/repository/user/query/UserMyPageQueryRepository.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
-import static lems.cowshed.domain.bookmark.QBookmark.*;
-import static lems.cowshed.domain.event.participation.QEventParticipation.*;
+import static lems.cowshed.domain.bookmark.BookmarkStatus.BOOKMARK;
+import static lems.cowshed.domain.bookmark.QBookmark.bookmark;
+import static lems.cowshed.domain.event.participation.QEventParticipation.eventParticipation;
 
 @Repository
 public class UserMyPageQueryRepository {
@@ -35,13 +35,13 @@ public class UserMyPageQueryRepository {
                         dynamicParticipatedEventId(lastEventId),
                         eventParticipation.user.id.eq(userId)
                 )
-                .orderBy(eventParticipation.event.id.desc())
+                .orderBy(eventParticipation.eventId.desc())
                 .limit(pageSize + 1)
                 .fetch();
 
         boolean hasNext = pageSize < content.size();
 
-        if(hasNext){
+        if (hasNext) {
             content.remove(content.size() - 1);
         }
         return new SliceImpl<>(content, PageRequest.of(0, pageSize), hasNext);
@@ -60,14 +60,14 @@ public class UserMyPageQueryRepository {
 
         boolean hasNext = pageSize < content.size();
 
-        if(hasNext){
+        if (hasNext) {
             content.remove(content.size() - 1);
         }
         return new SliceImpl<>(content, PageRequest.of(0, pageSize), hasNext);
     }
 
     private BooleanBuilder dynamicParticipatedEventId(Long lastEventId) {
-        return nullSafeBuilder(() -> eventParticipation.event.id.lt(lastEventId));
+        return nullSafeBuilder(() -> eventParticipation.eventId.lt(lastEventId));
     }
 
     private BooleanBuilder dynamicBookmarkEventId(Long eventId) {

--- a/src/main/java/lems/cowshed/service/event/EventParticipationService.java
+++ b/src/main/java/lems/cowshed/service/event/EventParticipationService.java
@@ -31,15 +31,16 @@ public class EventParticipationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
 
-        Event event = eventRepository.findPessimisticById(eventId)
+        Event event = eventRepository.finByIdWithOptimisticLock(eventId)
                 .orElseThrow(() -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));
 
         long participantCount = eventParticipantRepository.getParticipationCountById(event.getId());
+
         if (isNotParticipateToEvent(event, participantCount)) {
             throw new BusinessException(EVENT_CAPACITY, EVENT_CAPACITY_OVER);
         }
 
-        EventParticipation participation = EventParticipation.of(user, event);
+        EventParticipation participation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(participation);
         return participation.getId();
     }

--- a/src/main/java/lems/cowshed/service/regular/event/RegularEventService.java
+++ b/src/main/java/lems/cowshed/service/regular/event/RegularEventService.java
@@ -1,6 +1,7 @@
 package lems.cowshed.service.regular.event;
 
 import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.participation.EventParticipation;
 import lems.cowshed.domain.regular.event.RegularEvent;
 import lems.cowshed.domain.regular.event.RegularEventEditCommand;
 import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
@@ -12,7 +13,7 @@ import lems.cowshed.dto.regular.event.response.RegularEventSearchResponse;
 import lems.cowshed.dto.regular.event.response.RegularEventSimpleInfo;
 import lems.cowshed.global.exception.NotFoundException;
 import lems.cowshed.repository.event.EventRepository;
-import lems.cowshed.repository.event.query.EventQueryRepository;
+import lems.cowshed.repository.event.participation.EventParticipantRepository;
 import lems.cowshed.repository.regular.event.RegularEventQueryRepository;
 import lems.cowshed.repository.regular.event.RegularEventRepository;
 import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
@@ -35,7 +36,7 @@ import static lems.cowshed.global.exception.Reason.REGULAR_EVENT_ID;
 public class RegularEventService {
 
     private final EventRepository eventRepository;
-    private final EventQueryRepository eventQueryRepository;
+    private final EventParticipantRepository eventParticipantRepository;
     private final RegularEventRepository regularEventRepository;
     private final RegularEventQueryRepository regularEventQueryRepository;
     private final RegularEventParticipationRepository regularEventParticipationRepository;
@@ -99,10 +100,10 @@ public class RegularEventService {
         List<Long> regularEventIds = getRegularEventIds(regularEvents);
 
         List<Long> eventIds = getEventIds(regularEvents);
-        List<Event> eventFetchParticipants = eventQueryRepository.findEventFetchParticipantsIn(eventIds);
+        List<EventParticipation> participants = eventParticipantRepository.findByEventIdIn(eventIds);
 
         List<RegularEvent> regularFetchParticipation = regularEventRepository.findByIdInFetchParticipation(regularEventIds);
-        return RegularEventSearchResponse.of(regularEvents, regularFetchParticipation, eventFetchParticipants, userId, slice.hasNext());
+        return RegularEventSearchResponse.of(regularEvents, regularFetchParticipation, participants, userId, slice.hasNext());
     }
 
     private List<Long> getRegularEventIds(List<RegularEvent> regularEvents) {

--- a/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
@@ -115,13 +115,14 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
     void findEventWithParticipatedWhenTwoUserIds() {
         //given
         User user = createUser("테스터", INTP);
-        Event event = createEvent("산책 모임", "테스터");
-        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
-
         User user2 = createUser("테스터2", ESFJ);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         userRepository.saveAll(List.of(user, user2));
+
+        Event event = createEvent("산책 모임", "테스터");
         eventRepository.save(event);
+
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         //when
@@ -197,13 +198,14 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         //given
         User user = createUser("테스터", INTP);
         User user2 = createUser("테스터2", ESFJ);
+        userRepository.saveAll(List.of(user, user2));
+
         Event event = createEvent("산책 모임", "테스터");
+        eventRepository.save(event);
 
         EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
 
-        userRepository.saveAll(List.of(user, user2));
-        eventRepository.save(event);
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         //when

--- a/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
@@ -1,23 +1,23 @@
 package lems.cowshed.domain.event.query;
 
 import lems.cowshed.IntegrationTestSupport;
-import lems.cowshed.dto.event.response.query.EventParticipantQueryDto;
 import lems.cowshed.domain.bookmark.Bookmark;
-import lems.cowshed.repository.bookmark.BookmarkRepository;
 import lems.cowshed.domain.event.Event;
-import lems.cowshed.repository.event.EventRepository;
+import lems.cowshed.domain.event.participation.EventParticipation;
 import lems.cowshed.domain.regular.event.RegularEvent;
+import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
+import lems.cowshed.domain.user.Mbti;
+import lems.cowshed.domain.user.User;
+import lems.cowshed.dto.event.response.query.EventParticipantQueryDto;
+import lems.cowshed.repository.bookmark.BookmarkRepository;
+import lems.cowshed.repository.event.EventRepository;
+import lems.cowshed.repository.event.participation.EventParticipantRepository;
 import lems.cowshed.repository.event.query.BookmarkedEventSimpleInfoQuery;
 import lems.cowshed.repository.event.query.EventQueryRepository;
 import lems.cowshed.repository.event.query.ParticipatingEventSimpleInfoQuery;
 import lems.cowshed.repository.regular.event.RegularEventRepository;
-import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
 import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
-import lems.cowshed.domain.user.Mbti;
-import lems.cowshed.domain.user.User;
 import lems.cowshed.repository.user.UserRepository;
-import lems.cowshed.domain.event.participation.EventParticipation;
-import lems.cowshed.repository.event.participation.EventParticipantRepository;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +29,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static lems.cowshed.domain.bookmark.BookmarkStatus.BOOKMARK;
-import static lems.cowshed.domain.user.Mbti.*;
+import static lems.cowshed.domain.user.Mbti.ESFJ;
+import static lems.cowshed.domain.user.Mbti.INTP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EventQueryRepositoryTest extends IntegrationTestSupport {
@@ -56,34 +57,11 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
     BookmarkRepository bookmarkRepository;
 
     @BeforeEach
-    public void cleanUp(){
+    public void cleanUp() {
         eventParticipantRepository.deleteAllInBatch();
         bookmarkRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         eventRepository.deleteAllInBatch();
-    }
-
-    @DisplayName("모임과 모임 인원 정보를 함께 조회 한다.")
-    @Test
-    void findEventFetchParticipants() {
-        //given
-        User user = createUser("테스터", INTP);
-        User user2 = createUser("테스터2", INTJ);
-        userRepository.saveAll(List.of(user, user2));
-
-        Event event = createEvent("산책 모임", "테스터");
-        eventRepository.save(event);
-
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
-        eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
-
-        //when
-        Event findEvent = eventQueryRepository.findEventFetchParticipants(event.getId());
-
-        //then
-        List<EventParticipation> participants = findEvent.getParticipants();
-        assertThat(participants).hasSize(2);
     }
 
     @DisplayName("정기 모임과 정기 모임 참여 정보를 함께 조회 한다.")
@@ -120,7 +98,7 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         Event event = createEvent("산책 모임", "테스터");
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(eventParticipation);
 
         //when
@@ -138,10 +116,10 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         //given
         User user = createUser("테스터", INTP);
         Event event = createEvent("산책 모임", "테스터");
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
 
         User user2 = createUser("테스터2", ESFJ);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         userRepository.saveAll(List.of(user, user2));
         eventRepository.save(event);
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
@@ -185,7 +163,7 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         userRepository.save(user);
         Event event = createEvent("산책 모임", "테스터");
         eventRepository.save(event);
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(eventParticipation);
 
         //when
@@ -221,8 +199,8 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         User user2 = createUser("테스터2", ESFJ);
         Event event = createEvent("산책 모임", "테스터");
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
 
         userRepository.saveAll(List.of(user, user2));
         eventRepository.save(event);
@@ -237,11 +215,11 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
                 .containsExactlyInAnyOrder("테스터", "테스터2");
     }
 
-    private RegularEvent createRegularEvent(Event event, String name, String location){
+    private RegularEvent createRegularEvent(Event event, String name, String location) {
         return RegularEvent.builder()
                 .name(name)
                 .event(event)
-                .dateTime(LocalDateTime.of(2025,5,5,12,0,0))
+                .dateTime(LocalDateTime.of(2025, 5, 5, 12, 0, 0))
                 .location(location)
                 .capacity(50)
                 .build();

--- a/src/test/java/lems/cowshed/service/RegularEventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/RegularEventServiceTest.java
@@ -369,7 +369,7 @@ class RegularEventServiceTest extends IntegrationTestSupport {
         Event event = createEvent(author, Category.GAME, "테스트 모임");
         eventRepository.save(event);
 
-        EventParticipation participation = EventParticipation.of(user, event);
+        EventParticipation participation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(participation);
 
         RegularEvent regularEvent = createRegularEvent(user.getId(), event, "정기 모임", "장소");

--- a/src/test/java/lems/cowshed/service/event/EventParticipationServiceTest.java
+++ b/src/test/java/lems/cowshed/service/event/EventParticipationServiceTest.java
@@ -61,7 +61,7 @@ class EventParticipationServiceTest extends IntegrationTestSupport {
 
     @Disabled
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @DisplayName("최대 인원이 3명인 모임에 5명의 회원이 동시에 참가 하면 3명만 참여 할 수 있다.")
+    @DisplayName("최대 인원이 3명인 모임에 5명의 회원이 동시에 참가 하면 1명만 참여 할 수 있다.")
     @Test
     void saveEventParticipation_WhenFiveUsersJoin_ThenThreeParticipantsAllowed() throws Exception {
         //given

--- a/src/test/java/lems/cowshed/service/event/EventParticipationServiceTest.java
+++ b/src/test/java/lems/cowshed/service/event/EventParticipationServiceTest.java
@@ -2,13 +2,13 @@ package lems.cowshed.service.event;
 
 import lems.cowshed.IntegrationTestSupport;
 import lems.cowshed.domain.event.Event;
-import lems.cowshed.repository.event.EventRepository;
 import lems.cowshed.domain.event.participation.EventParticipation;
 import lems.cowshed.domain.user.User;
-import lems.cowshed.repository.user.UserRepository;
-import lems.cowshed.repository.event.participation.EventParticipantRepository;
 import lems.cowshed.global.exception.BusinessException;
 import lems.cowshed.global.exception.NotFoundException;
+import lems.cowshed.repository.event.EventRepository;
+import lems.cowshed.repository.event.participation.EventParticipantRepository;
+import lems.cowshed.repository.user.UserRepository;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,12 +52,11 @@ class EventParticipationServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         //when
-        long userEventId = eventParticipationService.saveEventParticipation(event.getId(), user.getId());
+        eventParticipationService.saveEventParticipation(event.getId(), user.getId());
 
         //then
-        EventParticipation eventParticipation = eventParticipantRepository.findById(userEventId).orElseThrow();
-        assertThat(eventParticipation.getUser()).extracting("username").isEqualTo("테스터");
-        assertThat(eventParticipation.getEvent()).extracting("name").isEqualTo("자전거 모임");
+        Event findEvent = eventRepository.findById(event.getId()).orElseThrow();
+        assertThat(findEvent.getName()).isEqualTo("자전거 모임");
     }
 
     @Disabled
@@ -70,7 +69,7 @@ class EventParticipationServiceTest extends IntegrationTestSupport {
         ExecutorService executorService = Executors.newFixedThreadPool(5);
         CountDownLatch countDownLatch = new CountDownLatch(taskCount);
 
-        Event findEvent =  eventRepository.save(createEvent("테스터", "테스트 모임", 3));
+        Event findEvent = eventRepository.save(createEvent("테스터", "테스트 모임", 3));
 
         List<User> users = Stream
                 .generate(() -> {
@@ -114,7 +113,7 @@ class EventParticipationServiceTest extends IntegrationTestSupport {
         Event event = createEvent("테스터", "테스트 모임");
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(eventParticipation);
 
         //when
@@ -135,7 +134,7 @@ class EventParticipationServiceTest extends IntegrationTestSupport {
         Event event = createEvent("테스터", "테스트 모임");
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(eventParticipation);
 
         //when //then

--- a/src/test/java/lems/cowshed/service/event/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/event/EventServiceTest.java
@@ -179,7 +179,7 @@ class EventServiceTest extends IntegrationTestSupport {
         Event event = createEvent("테스터", "자전거 모임");
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
         eventParticipantRepository.save(eventParticipation);
 
         //when
@@ -241,8 +241,8 @@ class EventServiceTest extends IntegrationTestSupport {
         Event event = createEvent("테스터", "자전거 모임");
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         //when
@@ -387,13 +387,13 @@ class EventServiceTest extends IntegrationTestSupport {
         //given
         User user = createUser("테스터", INTP);
         User user2 = createUser("테스터2", ISTP);
-        Event event = createEvent("산책 모임", "테스터");
-
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
-
         userRepository.saveAll(List.of(user, user2));
+
+        Event event = createEvent("산책 모임", "테스터");
         eventRepository.save(event);
+
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         //when
@@ -478,8 +478,8 @@ class EventServiceTest extends IntegrationTestSupport {
         Event event = createEvent("테스터", "자전거 모임", 2);
         eventRepository.save(event);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         EventUpdateRequestDto updateRequest = createUpdateRequestDto("산책 모임", 1);
@@ -708,10 +708,11 @@ class EventServiceTest extends IntegrationTestSupport {
         String searchKeyword = "검색";
         Category searchCategory = Category.PET;
         Event event = createEvent("테스터", "모임 " + searchKeyword, "내용", searchCategory);
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user2, event);
         eventRepository.save(event);
 
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user2, event.getId());
+        eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
         EventSearchCondition searchCondition = createSearchCondition(searchKeyword, searchCategory);
 
         //when

--- a/src/test/java/lems/cowshed/service/user/UserServiceTest.java
+++ b/src/test/java/lems/cowshed/service/user/UserServiceTest.java
@@ -217,8 +217,8 @@ class UserServiceTest extends IntegrationTestSupport {
         User user = createUser("테스터", INTP);
         userRepository.save(user);
 
-        EventParticipation eventParticipation = EventParticipation.of(user, event);
-        EventParticipation eventParticipation2 = EventParticipation.of(user, event2);
+        EventParticipation eventParticipation = EventParticipation.of(user, event.getId());
+        EventParticipation eventParticipation2 = EventParticipation.of(user, event2.getId());
         eventParticipantRepository.saveAll(List.of(eventParticipation, eventParticipation2));
 
         Bookmark bookmark = createBookmark(user.getId());


### PR DESCRIPTION
##
### 🌱 작업 내용
### [ 모임 참여 동시성 제어 ]
- 한 모임에 동시 참여시 낙관적 락을 활용하여 1명만 통과 하도록 수정
- 낙관적 락 적용시 모임 참여 테이블의 모임 ID 외래키로 인한 데드락 발생 
- 모임 참여 테이블 외래키 제거와 엔티티 연관관계 제거
- 관련된 내용 : https://heedb.tistory.com/65

##
### 📚 테스트
<img width="861" height="246" alt="image" src="https://github.com/user-attachments/assets/5ed7fef5-de82-43b4-bfc1-335f02578241" />
