### PR TITLE
refactor: 정기 모임 / 정기 모임 참여 연관 관계 제거

### DIFF
--- a/src/main/java/lems/cowshed/domain/regular/event/RegularEvent.java
+++ b/src/main/java/lems/cowshed/domain/regular/event/RegularEvent.java
@@ -3,23 +3,25 @@ package lems.cowshed.domain.regular.event;
 import jakarta.persistence.*;
 import lems.cowshed.domain.BaseEntity;
 import lems.cowshed.domain.event.Event;
-import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
 import lems.cowshed.global.exception.BusinessException;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import static lems.cowshed.global.exception.Message.*;
-import static lems.cowshed.global.exception.Reason.*;
+
+import static lems.cowshed.global.exception.Message.REGULAR_EVENT_INVALID_UPDATE_CAPACITY;
+import static lems.cowshed.global.exception.Reason.REGULAR_EVENT_PARTICIPATION;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class RegularEvent extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
@@ -32,8 +34,8 @@ public class RegularEvent extends BaseEntity {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @OneToMany(mappedBy = "regularEvent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RegularEventParticipation> participations = new ArrayList<>();
+    @Version
+    private Long version;
 
     @Builder
     private RegularEvent(String name, LocalDateTime dateTime, String location,
@@ -47,7 +49,7 @@ public class RegularEvent extends BaseEntity {
     }
 
     public static RegularEvent of(String name, LocalDateTime dateTime, String location,
-                                  int capacity, Long userId, Event event){
+                                  int capacity, Long userId, Event event) {
         return RegularEvent.builder()
                 .name(name)
                 .dateTime(dateTime)
@@ -58,7 +60,7 @@ public class RegularEvent extends BaseEntity {
                 .build();
     }
 
-    public boolean isNotPossibleParticipation(long participantCount) {
+    public boolean isNotJoinAble(long participantCount) {
         return capacity <= participantCount;
     }
 
@@ -75,7 +77,7 @@ public class RegularEvent extends BaseEntity {
     }
 
     public void updateCapacity(long participantCount, int updateCapacity) {
-        if(participantCount > updateCapacity){
+        if (participantCount > updateCapacity) {
             throw new BusinessException(REGULAR_EVENT_PARTICIPATION, REGULAR_EVENT_INVALID_UPDATE_CAPACITY);
         }
         this.capacity = updateCapacity;

--- a/src/main/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipation.java
+++ b/src/main/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipation.java
@@ -1,8 +1,10 @@
 package lems.cowshed.domain.regular.event.participation;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lems.cowshed.domain.BaseEntity;
-import lems.cowshed.domain.regular.event.RegularEvent;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,33 +12,28 @@ import lombok.Getter;
 @Entity
 public class RegularEventParticipation extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long userId;
+    private long userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "regular_event_id")
-    private RegularEvent regularEvent;
+    private long regularEventId;
 
-    protected RegularEventParticipation() {}
+    protected RegularEventParticipation() {
+    }
 
     @Builder
-    private RegularEventParticipation(Long userId) {
+    private RegularEventParticipation(long userId, long regularEventId) {
         this.userId = userId;
+        this.regularEventId = regularEventId;
     }
 
-    public static RegularEventParticipation of(Long userId, RegularEvent regularEvent){
-        RegularEventParticipation regularEventParticipation = RegularEventParticipation.builder()
+    public static RegularEventParticipation of(long userId, long regularEventId) {
+        return RegularEventParticipation.builder()
                 .userId(userId)
+                .regularEventId(regularEventId)
                 .build();
 
-        regularEventParticipation.connectRegularEvent(regularEvent);
-        return regularEventParticipation;
-    }
-
-    public void connectRegularEvent(RegularEvent regularEvent){
-        this.regularEvent = regularEvent;
-        regularEvent.getParticipations().add(this);
     }
 }

--- a/src/main/java/lems/cowshed/dto/regular/event/response/RegularEventInfo.java
+++ b/src/main/java/lems/cowshed/dto/regular/event/response/RegularEventInfo.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class RegularEventInfo {
@@ -32,12 +33,12 @@ public class RegularEventInfo {
         this.isRegularRegistrant = isRegularRegistrant;
     }
 
-    public static RegularEventInfo of(RegularEvent regularEvent, Long userId){
+    public static RegularEventInfo of(RegularEvent regularEvent, List<RegularEventParticipation> participants, Long userId){
 
         boolean isRegularRegistrant = regularEvent.getUserId().equals(userId);
 
-        Long participationId = regularEvent.getParticipations().stream()
-                .filter(rep -> rep.getUserId().equals(userId))
+        Long participationId = participants.stream()
+                .filter(rep -> rep.getUserId() == userId)
                 .map(RegularEventParticipation::getId)
                 .findFirst()
                 .orElse(null);
@@ -49,7 +50,7 @@ public class RegularEventInfo {
                 .location(regularEvent.getLocation())
                 .dateTime(regularEvent.getDateTime())
                 .capacity(regularEvent.getCapacity())
-                .applicants(regularEvent.getParticipations().size())
+                .applicants(participants.size())
                 .isRegularRegistrant(isRegularRegistrant)
                 .build();
     }

--- a/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
+++ b/src/main/java/lems/cowshed/repository/event/query/EventQueryRepository.java
@@ -52,16 +52,6 @@ public class EventQueryRepository {
                 .fetch();
     }
 
-    public List<RegularEvent> findRegularEventsFetchParticipants(Long eventId) {
-        return queryFactory
-                .select(regularEvent).distinct()
-                .from(regularEvent)
-                .join(regularEvent.event, event)
-                .leftJoin(regularEvent.participations, regularEventParticipation).fetchJoin()
-                .where(regularEvent.event.id.eq(eventId))
-                .fetch();
-    }
-
     public List<ParticipatingEventSimpleInfoQuery> findEventsParticipatedByUserWithApplicants(List<Long> eventIds) {
         // 회원이 참여한 모임과 참여 인원수 북마크 여부 X
         return queryFactory

--- a/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
+++ b/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
@@ -17,14 +17,11 @@ public interface RegularEventRepository extends JpaRepository<RegularEvent, Long
     @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
     Optional<RegularEvent> findWithOptimisticLockById(Long regularId);
 
-    @Query("select count(rep) from RegularEventParticipation rep join rep.regularEvent re where re.id = :regularId")
+    @Query("select count(rep) from RegularEventParticipation rep join RegularEvent re on rep.regularEventId = re.id where re.id = :regularId")
     long getParticipantCount(@Param("regularId") long regularId);
 
-    @Query("select rep.userId from RegularEventParticipation rep join rep.regularEvent re where re.id = :regularId")
+    @Query("select rep.userId from RegularEventParticipation rep join RegularEvent re on rep.regularEventId = re.id where re.id = :regularId")
     List<Long> findParticipantsUserIdsByRegularId(@Param("regularId") Long regularId);
-
-    @Query("select distinct re from RegularEvent re left join fetch re.participations rep where re.id in :regularIds")
-    List<RegularEvent> findByIdInFetchParticipation(@Param("regularIds") List<Long> regularEventIds);
 
     Slice<RegularEvent> findByEventId(Long eventId, Pageable pageable);
 

--- a/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
+++ b/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
@@ -27,4 +27,6 @@ public interface RegularEventRepository extends JpaRepository<RegularEvent, Long
     List<RegularEvent> findByIdInFetchParticipation(@Param("regularIds") List<Long> regularEventIds);
 
     Slice<RegularEvent> findByEventId(Long eventId, Pageable pageable);
+
+    List<RegularEvent> findByEventId(long eventId);
 }

--- a/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
+++ b/src/main/java/lems/cowshed/repository/regular/event/RegularEventRepository.java
@@ -14,17 +14,14 @@ import java.util.Optional;
 
 public interface RegularEventRepository extends JpaRepository<RegularEvent, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<RegularEvent> findWithLockById(Long regularId);
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    Optional<RegularEvent> findWithOptimisticLockById(Long regularId);
 
     @Query("select count(rep) from RegularEventParticipation rep join rep.regularEvent re where re.id = :regularId")
     long getParticipantCount(@Param("regularId") long regularId);
 
     @Query("select rep.userId from RegularEventParticipation rep join rep.regularEvent re where re.id = :regularId")
     List<Long> findParticipantsUserIdsByRegularId(@Param("regularId") Long regularId);
-
-    @Query("select re from RegularEvent re left join fetch re.participations rep where re.id = :regularId")
-    RegularEvent findByIdFetchParticipation(@Param("regularId") Long regularId);
 
     @Query("select distinct re from RegularEvent re left join fetch re.participations rep where re.id in :regularIds")
     List<RegularEvent> findByIdInFetchParticipation(@Param("regularIds") List<Long> regularEventIds);

--- a/src/main/java/lems/cowshed/repository/regular/event/participation/RegularEventParticipationRepository.java
+++ b/src/main/java/lems/cowshed/repository/regular/event/participation/RegularEventParticipationRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface RegularEventParticipationRepository extends JpaRepository<RegularEventParticipation, Long> {
 
-    @Query("select COUNT(rep) from RegularEventParticipation rep where rep.regularEvent.id = :regularId")
+    @Query("select COUNT(rep) from RegularEventParticipation rep where rep.regularEventId = :regularId")
     long getParticipantCountByRegularId(@Param("regularId") Long regularId);
 
     Optional<RegularEventParticipation> findByIdAndUserId(Long id, Long userId);
@@ -18,4 +18,7 @@ public interface RegularEventParticipationRepository extends JpaRepository<Regul
     Optional<RegularEventParticipation> findByRegularEventIdAndUserId(Long regularEventId, Long userId);
 
     List<RegularEventParticipation> findByRegularEventId(long regularEventId);
+
+    @Query("select rep from RegularEventParticipation rep where rep.regularEventId in :regularEventIds")
+    List<RegularEventParticipation> findByRegularEventIdIn(@Param("regularEventIds") List<Long> regularEventIds);
 }

--- a/src/main/java/lems/cowshed/repository/regular/event/participation/RegularEventParticipationRepository.java
+++ b/src/main/java/lems/cowshed/repository/regular/event/participation/RegularEventParticipationRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RegularEventParticipationRepository extends JpaRepository<RegularEventParticipation, Long> {
@@ -15,4 +16,6 @@ public interface RegularEventParticipationRepository extends JpaRepository<Regul
     Optional<RegularEventParticipation> findByIdAndUserId(Long id, Long userId);
 
     Optional<RegularEventParticipation> findByRegularEventIdAndUserId(Long regularEventId, Long userId);
+
+    List<RegularEventParticipation> findByRegularEventId(long regularEventId);
 }

--- a/src/main/java/lems/cowshed/service/regular/event/RegularEventParticipationService.java
+++ b/src/main/java/lems/cowshed/service/regular/event/RegularEventParticipationService.java
@@ -1,23 +1,23 @@
 package lems.cowshed.service.regular.event;
 
+import lems.cowshed.domain.regular.event.RegularEvent;
+import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
+import lems.cowshed.domain.user.User;
 import lems.cowshed.dto.regular.event.response.RegularParticipantDetails;
 import lems.cowshed.dto.regular.event.response.RegularParticipantsInfo;
-import lems.cowshed.domain.regular.event.RegularEvent;
-import lems.cowshed.repository.regular.event.RegularEventRepository;
-import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
-import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
-import lems.cowshed.domain.user.User;
-import lems.cowshed.repository.user.UserRepository;
 import lems.cowshed.global.exception.BusinessException;
 import lems.cowshed.global.exception.NotFoundException;
+import lems.cowshed.repository.regular.event.RegularEventRepository;
+import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
+import lems.cowshed.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static lems.cowshed.global.exception.Message.*;
 import static lems.cowshed.global.exception.Reason.*;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,35 +30,33 @@ public class RegularEventParticipationService {
 
     @Transactional
     public Long saveParticipation(Long regularId, Long userId) {
+        alreadyParticipateCheck(regularId, userId);
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_ID, USER_NOT_FOUND));
 
-        participationRepository.findByRegularEventIdAndUserId(regularId, userId)
-                .ifPresent(participation -> {
-                    throw new BusinessException(REGULAR_EVENT_ID, REGULAR_EVENT_ALREADY_PARTICIPATION);
-                });
-
-        RegularEvent regularEvent = regularEventRepository.findWithLockById(regularId)
+        RegularEvent regularEvent = regularEventRepository.findWithOptimisticLockById(regularId)
                 .orElseThrow(() -> new NotFoundException(REGULAR_EVENT_ID, REGULAR_EVENT_NOT_FOUND));
 
         long participantCount = regularEventRepository.getParticipantCount(regularEvent.getId());
 
-        if(regularEvent.isNotPossibleParticipation(participantCount)){
+        if (regularEvent.isNotJoinAble(participantCount)) {
             throw new BusinessException(REGULAR_EVENT_PARTICIPATION, REGULAR_EVENT_NOT_POSSIBLE_PARTICIPATION);
         }
 
-        RegularEventParticipation participation = participationRepository.save(RegularEventParticipation.of(user.getId(), regularEvent));
+        RegularEventParticipation participation = participationRepository.save(
+                RegularEventParticipation.of(user.getId(), regularEvent.getId())
+        );
         return participation.getId();
     }
 
     public RegularParticipantsInfo getRegularParticipants(Long regularId) {
-        RegularEvent regularEvent = regularEventRepository.findByIdFetchParticipation(regularId);
-        List<RegularEventParticipation> regularParticipants = regularEvent.getParticipations();
-        List<Long> participantsUserIds = getParticipantsUserIds(regularParticipants);
-        List<User> participants = userRepository.findByIdIn(participantsUserIds);
+        RegularEvent regularEvent = regularEventRepository.findById(regularId)
+                .orElseThrow(() -> new NotFoundException(REGULAR_EVENT_ID, REGULAR_EVENT_NOT_FOUND));
 
-        List<RegularParticipantDetails> details = convertDetails(participants);
-        return RegularParticipantsInfo.of(details, participantsUserIds.size(), regularEvent.getCapacity());
+        List<RegularEventParticipation> participants = participationRepository.findByRegularEventId(regularEvent.getId());
+        List<User> users = findUsersFrom(participants);
+        return RegularParticipantsInfo.of(convertDtoList(users), participants.size(), regularEvent.getCapacity());
     }
 
     @Transactional
@@ -69,13 +67,21 @@ public class RegularEventParticipationService {
         participationRepository.delete(participation);
     }
 
-    private List<Long> getParticipantsUserIds(List<RegularEventParticipation> participants) {
-        return participants.stream()
-                .map(RegularEventParticipation::getUserId)
-                .toList();
+    private void alreadyParticipateCheck(Long regularId, Long userId) {
+        participationRepository.findByRegularEventIdAndUserId(regularId, userId)
+                .ifPresent(participation -> {
+                    throw new BusinessException(REGULAR_EVENT_ID, REGULAR_EVENT_ALREADY_PARTICIPATION);
+                });
     }
 
-    private List<RegularParticipantDetails> convertDetails(List<User> participants) {
+    private List<User> findUsersFrom(List<RegularEventParticipation> participants) {
+        List<Long> userIds = participants.stream()
+                .map(RegularEventParticipation::getUserId)
+                .toList();
+        return userRepository.findByIdIn(userIds);
+    }
+
+    private List<RegularParticipantDetails> convertDtoList(List<User> participants) {
         return participants.stream()
                 .map(user -> RegularParticipantDetails.of(user.getUsername(), user.getMbti()))
                 .toList();

--- a/src/main/java/lems/cowshed/service/regular/event/RegularEventService.java
+++ b/src/main/java/lems/cowshed/service/regular/event/RegularEventService.java
@@ -70,7 +70,7 @@ public class RegularEventService {
         List<Long> regularEventIds = extractId(regularEvents);
         List<RegularEventParticipation> participants = regularEventParticipationRepository.findByRegularEventIdIn(regularEventIds);
 
-        return RegularEventPagingInfo.of(regularEvents, groupedById(participants), userId, pagingInfo.hasNext());
+        return RegularEventPagingInfo.of(regularEvents, groupedRegularEventId(participants), userId, pagingInfo.hasNext());
     }
 
     @Transactional
@@ -103,11 +103,13 @@ public class RegularEventService {
         List<RegularEvent> regularEvents = slice.getContent();
 
         List<Long> regularEventIds = extractId(regularEvents);
+        List<RegularEventParticipation> regularEventParticipants = regularEventParticipationRepository.findByRegularEventIdIn(regularEventIds);
+        Map<Long, List<RegularEventParticipation>> groupedRegularEventIdMap = groupedRegularEventId(regularEventParticipants);
+
         List<Long> eventIds = getEventIds(regularEvents);
         List<EventParticipation> participants = eventParticipantRepository.findByEventIdIn(eventIds);
 
-        List<RegularEvent> regularFetchParticipation = regularEventRepository.findByIdInFetchParticipation(regularEventIds);
-        return RegularEventSearchResponse.of(regularEvents, regularFetchParticipation, participants, userId, slice.hasNext());
+        return RegularEventSearchResponse.of(regularEvents, groupedRegularEventIdMap, participants, userId, slice.hasNext());
     }
 
     private List<Long> extractId(List<RegularEvent> regularEvents) {
@@ -120,7 +122,7 @@ public class RegularEventService {
         return RegularEventParticipation.of(userId, regularEvent.getId());
     }
 
-    private Map<Long, List<RegularEventParticipation>> groupedById(List<RegularEventParticipation> participants) {
+    private Map<Long, List<RegularEventParticipation>> groupedRegularEventId(List<RegularEventParticipation> participants) {
         return participants.stream()
                 .collect(Collectors.groupingBy(
                         RegularEventParticipation::getRegularEventId

--- a/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/event/query/EventQueryRepositoryTest.java
@@ -64,30 +64,6 @@ class EventQueryRepositoryTest extends IntegrationTestSupport {
         eventRepository.deleteAllInBatch();
     }
 
-    @DisplayName("정기 모임과 정기 모임 참여 정보를 함께 조회 한다.")
-    @Test
-    void findRegularEventsFetchParticipants() {
-        //given
-        User user = createUser("테스터", INTP);
-        userRepository.save(user);
-
-        Event event = createEvent("산책 모임", "테스터");
-        eventRepository.save(event);
-
-        RegularEvent regularEvent = createRegularEvent(event, "테스트 모임", "테스트 장소");
-        regularEventRepository.save(regularEvent);
-
-        RegularEventParticipation regularEventParticipation = RegularEventParticipation.of(user.getId(), regularEvent);
-        regularEventParticipationRepository.save(regularEventParticipation);
-
-        //when
-        List<RegularEvent> regularEvents = eventQueryRepository.findRegularEventsFetchParticipants(event.getId());
-
-        //then
-        assertThat(regularEvents).hasSize(1);
-        assertThat(regularEvents.get(0).getName().equals("테스트 모임"));
-    }
-
     @DisplayName("모임에 대한 정보와 참여 인원수를 조회 한다.")
     @Test
     void findEventWithApplicantUserIds() {

--- a/src/test/java/lems/cowshed/domain/regular/event/RegularEventRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/regular/event/RegularEventRepositoryTest.java
@@ -2,12 +2,12 @@ package lems.cowshed.domain.regular.event;
 
 import lems.cowshed.IntegrationTestSupport;
 import lems.cowshed.domain.event.Event;
-import lems.cowshed.repository.event.EventRepository;
 import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
-import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
 import lems.cowshed.domain.user.Mbti;
 import lems.cowshed.domain.user.User;
+import lems.cowshed.repository.event.EventRepository;
 import lems.cowshed.repository.regular.event.RegularEventRepository;
+import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
 import lems.cowshed.repository.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +16,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static lems.cowshed.domain.user.Mbti.*;
-import static org.assertj.core.api.Assertions.*;
+import static lems.cowshed.domain.user.Mbti.INTP;
+import static lems.cowshed.domain.user.Mbti.ISTP;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RegularEventRepositoryTest extends IntegrationTestSupport {
 
@@ -47,8 +48,8 @@ class RegularEventRepositoryTest extends IntegrationTestSupport {
         RegularEvent regularEvent = createRegularEvent(event, "정기 모임", "정기 모임 장소");
         regularEventRepository.save(regularEvent);
 
-        RegularEventParticipation participation = RegularEventParticipation.of(user.getId(), regularEvent);
-        RegularEventParticipation participation2 = RegularEventParticipation.of(user2.getId(), regularEvent);
+        RegularEventParticipation participation = RegularEventParticipation.of(user.getId(), regularEvent.getId());
+        RegularEventParticipation participation2 = RegularEventParticipation.of(user2.getId(), regularEvent.getId());
         participationRepository.saveAll(List.of(participation, participation2));
 
         //when
@@ -59,30 +60,6 @@ class RegularEventRepositoryTest extends IntegrationTestSupport {
                 .containsExactlyInAnyOrder(
                         user.getId(), user2.getId()
                 );
-    }
-
-    @DisplayName("정기 모임 식별자들에 속하는 참여 정보를 같이 조회 한다.")
-    @Test
-    void findByIdInFetchParticipation() {
-        //given
-        Long userId = 1L;
-        RegularEvent regularEvent = createRegularEvent(null, "정기 모임", "장소");
-        RegularEventParticipation participation = createParticipation(userId);
-        participation.connectRegularEvent(regularEvent);
-
-        RegularEvent regularEvent2 = createRegularEvent(null, "정기 모임2", "장소2");
-        RegularEventParticipation participation2 = createParticipation(userId);
-        participation2.connectRegularEvent(regularEvent2);
-        regularEventRepository.saveAll(List.of(regularEvent, regularEvent2));
-
-        //when
-        List<Long> regularEventIds = List.of(regularEvent.getId(), regularEvent2.getId());
-        List<RegularEvent> regularEvents = regularEventRepository.findByIdInFetchParticipation(regularEventIds);
-
-        //then
-        assertThat(regularEvents).hasSize(2);
-        assertThat(regularEvents.get(0).getParticipations()).hasSize(1);
-        assertThat(regularEvents.get(1).getParticipations()).hasSize(1);
     }
 
     private User createUser(String username, Mbti mbti) {
@@ -98,17 +75,17 @@ class RegularEventRepositoryTest extends IntegrationTestSupport {
                 .build();
     }
 
-    private RegularEvent createRegularEvent(Event event, String name, String location){
+    private RegularEvent createRegularEvent(Event event, String name, String location) {
         return RegularEvent.builder()
                 .name(name)
                 .event(event)
-                .dateTime(LocalDateTime.of(2025,5,5,12,0,0))
+                .dateTime(LocalDateTime.of(2025, 5, 5, 12, 0, 0))
                 .location(location)
                 .capacity(50)
                 .build();
     }
 
-    private RegularEventParticipation createParticipation(Long userId){
+    private RegularEventParticipation createParticipation(Long userId) {
         return RegularEventParticipation.builder()
                 .userId(userId)
                 .build();

--- a/src/test/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipationRepositoryTest.java
+++ b/src/test/java/lems/cowshed/domain/regular/event/participation/RegularEventParticipationRepositoryTest.java
@@ -46,8 +46,8 @@ class RegularEventParticipationRepositoryTest extends IntegrationTestSupport {
         RegularEvent regularEvent = createRegularEvent(event, "정기모임", "장소", user.getId());
         regularEventRepository.save(regularEvent);
 
-        RegularEventParticipation regularEventParticipation = RegularEventParticipation.of(user.getId(), regularEvent);
-        RegularEventParticipation regularEventParticipation2 = RegularEventParticipation.of(user2.getId(), regularEvent);
+        RegularEventParticipation regularEventParticipation = RegularEventParticipation.of(user.getId(), regularEvent.getId());
+        RegularEventParticipation regularEventParticipation2 = RegularEventParticipation.of(user2.getId(), regularEvent.getId());
         participationRepository.saveAll(List.of(regularEventParticipation, regularEventParticipation2));
 
         //when

--- a/src/test/java/lems/cowshed/service/event/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/event/EventServiceTest.java
@@ -844,6 +844,6 @@ class EventServiceTest extends IntegrationTestSupport {
     }
 
     private RegularEventParticipation createRegularParticipation(Long userId, RegularEvent regularEvent){
-        return RegularEventParticipation.of(userId, regularEvent);
+        return RegularEventParticipation.of(userId, regularEvent.getId());
     }
 }


### PR DESCRIPTION
##
### 🌱 작업 내용
### [ 정기 모임 / 정기 모임 참여 연관 관계 제거 ]
- before : 양방향 연관 관계
- after: 연관 관계 x 

---
### [ 정기 모임 참여 낙관적 락 적용 ] 
- 동시성 문제 발생 시 최초 트랜잭션만 커밋

---
### [ 테스트 수정 ]
- 정기 모임 참여 생성시 정기 모임 ID 식별자 값 포함 하도록 수정

##
### 🔎스크린 샷
[ 테스트 ]
<img width="863" height="191" alt="image" src="https://github.com/user-attachments/assets/e9ce350a-eb3d-4215-985a-6d96cefabb5d" />

