### PR TITLE
feat: 기본 메트릭 설정 추가

### DIFF
--- a/src/main/java/lems/cowshed/config/MetricsConfig.java
+++ b/src/main/java/lems/cowshed/config/MetricsConfig.java
@@ -1,0 +1,20 @@
+package lems.cowshed.config;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
+
+    @Bean
+    public CountedAspect countedAspect(MeterRegistry registry) {
+        return new CountedAspect(registry);
+    }
+}


### PR DESCRIPTION
##
### 🌱 작업 내용
### 🛠 버그 수정 및 설정 추가
---
### [ 메트릭 측정용 AOP 빈 등록 ]

#### 🔍 문제 원인 (Issue Analysis)
- **현상**: 컨트롤러 및 서비스에 `@Timed`, `@Counted`를 적용했으나 `/actuator/prometheus` 엔드포인트에서 해당 메트릭이 조회되지 않는 문제
- **원인**: 어노테이션을 감지하여 로직을 주입하는 **AOP Aspect(TimedAspect, CountedAspect)**는 수동으로 빈 등록 필요

---
#### ✅ 수정 내용 (Changes)
`MetricsConfig` 설정을 통해 어노테이션 기반 메트릭 수집을 위한 구성

| 추가된 빈(Bean) | 역할 | 비고 |
| :--- | :--- | :--- |
| **`TimedAspect`** | `@Timed` 어노테이션이 붙은 메서드의 실행 시간 측정 활성화 | Prometheus 히스토그램 생성 |
| **`CountedAspect`** | `@Counted` 어노테이션이 붙은 메서드의 호출 횟수 측정 활성화 | 누적 카운터 생성 |