### PR TITLE
feat: 모임 페이징 조회 캐시 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	// 모니터링
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	//레디스
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/lems/cowshed/api/controller/CommonResponse.java
+++ b/src/main/java/lems/cowshed/api/controller/CommonResponse.java
@@ -6,35 +6,39 @@ import org.springframework.http.HttpStatus;
 import static lems.cowshed.api.controller.ResponseMessage.*;
 
 @Getter
-public class CommonResponse<T> extends Response{
+public class CommonResponse<T> extends Response {
 
-    private final T data;
+    private T data;
+
+    public CommonResponse() {
+    }
 
     public CommonResponse(HttpStatus httpStatus, T data, String message) {
         super(httpStatus, message);
         this.data = data;
     }
 
-    public static <T> CommonResponse<T> of(HttpStatus status, T data, String message){
+    public static <T> CommonResponse<T> of(HttpStatus status, T data, String message) {
         return new CommonResponse<>(status, data, message);
     }
 
-    public static <T> CommonResponse<T> of(HttpStatus status, T data){
+    public static <T> CommonResponse<T> of(HttpStatus status, T data) {
         return of(status, data, status.name());
     }
 
-    public static <T> CommonResponse<T> success(HttpStatus status, T data, String message){
+    public static <T> CommonResponse<T> success(HttpStatus status, T data, String message) {
         return new CommonResponse<>(status, data, message);
     }
-    public static <T> CommonResponse<T> success(T data, String message){
+
+    public static <T> CommonResponse<T> success(T data, String message) {
         return success(HttpStatus.OK, data, message);
     }
 
-    public static <T> CommonResponse<T> success(T data){
+    public static <T> CommonResponse<T> success(T data) {
         return success(HttpStatus.OK, data, HttpStatus.OK.name());
     }
 
-    public static <T> CommonResponse<T> success(){
+    public static <T> CommonResponse<T> success() {
         return success(HttpStatus.OK, null, SUCCESS.getMessage());
     }
 }

--- a/src/main/java/lems/cowshed/api/controller/Response.java
+++ b/src/main/java/lems/cowshed/api/controller/Response.java
@@ -2,18 +2,19 @@ package lems.cowshed.api.controller;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@NoArgsConstructor
 public class Response {
 
     @Schema(example = "HttpStatus.OK")
-    private final HttpStatus httpStatus;
+    private HttpStatus httpStatus;
     @Schema(example = "200")
-    private final int code;
+    private int code;
     @Schema(example = "OK")
-    private final String message;
+    private String message;
 
     public Response(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;

--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -9,6 +9,8 @@ import lems.cowshed.dto.event.request.EventUpdateRequestDto;
 import lems.cowshed.dto.event.response.*;
 import lems.cowshed.service.event.EventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
@@ -32,6 +34,7 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(response);
     }
 
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @Counted(value = "event.create", description = "모임 생성")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<Long> saveEvent(@ModelAttribute @Validated EventSaveRequestDto requestDto,
@@ -40,9 +43,10 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(eventId);
     }
 
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @PatchMapping("/{event-id}")
     public CommonResponse<Void> editEvent(@PathVariable("event-id") Long eventId,
-                                          @RequestBody @Validated EventUpdateRequestDto requestDto,
+                                          @ModelAttribute @Validated EventUpdateRequestDto requestDto,
                                           @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
         eventService.editEvent(eventId, requestDto, customUserDetails.getUsername());
         return CommonResponse.success();
@@ -54,6 +58,7 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(participantsInfo);
     }
 
+    @Cacheable(value = "eventFirstPage", key = "'page0'", condition = "#pageable.pageNumber == 0")
     @GetMapping
     public CommonResponse<EventsPagingResponse> getEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
                                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -96,6 +101,7 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(count);
     }
 
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @DeleteMapping("/{event-id}")
     public CommonResponse<Void> deleteEvent(@PathVariable("event-id") Long eventId,
                                             @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/lems/cowshed/config/RedisConfig.java
+++ b/src/main/java/lems/cowshed/config/RedisConfig.java
@@ -1,0 +1,68 @@
+package lems.cowshed.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()
+                .build();
+
+        return new LettuceConnectionFactory(config, clientConfig);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .entryTtl(Duration.ofMinutes(3));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/lems/cowshed/dto/event/request/EventUpdateRequestDto.java
+++ b/src/main/java/lems/cowshed/dto/event/request/EventUpdateRequestDto.java
@@ -3,34 +3,36 @@ package lems.cowshed.dto.event.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
-import lems.cowshed.dto.Enum;
 import lems.cowshed.domain.event.Category;
+import lems.cowshed.dto.Enum;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @Schema(description = "모임 수정")
 public class EventUpdateRequestDto {
 
     @NotBlank
     @Schema(description = "모임 이름", example = "새벽 한강 러닝 모임")
-    String name;
+    private String name;
 
     @Enum(message = "Category 타입을 확인해 주세요.")
     @Schema(description = "카테고리", example = "스포츠")
-    Category category;
+    private Category category;
 
     @NotBlank
     @Schema(description = "내용", example = "출근 전에 한강에서 같이 뛰실 분 구해요!!")
-    String content;
+    private String content;
 
     @Max(value = 100)
     @Schema(description = "수용 인원 ( 최대 100명 )", example = "50")
-    int capacity;
+    private int capacity;
 
     @Schema(description = "이미지 이름", example = "강아지.jpg")
-    MultipartFile file;
+    private MultipartFile file;
 
     @Builder
     private EventUpdateRequestDto(String name, Category category, String content,
@@ -42,6 +44,7 @@ public class EventUpdateRequestDto {
         this.file = file;
     }
 
-    private EventUpdateRequestDto() {}
+    private EventUpdateRequestDto() {
+    }
 
 }

--- a/src/main/java/lems/cowshed/dto/event/response/EventPagingInfo.java
+++ b/src/main/java/lems/cowshed/dto/event/response/EventPagingInfo.java
@@ -8,10 +8,12 @@ import lems.cowshed.domain.bookmark.BookmarkStatus;
 import lems.cowshed.domain.event.Event;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 @Schema(description = "메인 모임 리스트중 하나의 모임")
 public class EventPagingInfo implements EventIdProvider {
 

--- a/src/main/java/lems/cowshed/dto/event/response/EventsPagingResponse.java
+++ b/src/main/java/lems/cowshed/dto/event/response/EventsPagingResponse.java
@@ -3,19 +3,21 @@ package lems.cowshed.dto.event.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @Schema(description = "메인 페이지의 모임 리스트")
 public class EventsPagingResponse {
     private List<EventPagingInfo> content;
-    private boolean isLast;
+    private boolean last;
 
     @Builder
     public EventsPagingResponse(List<EventPagingInfo> content, boolean isLast) {
         this.content = content;
-        this.isLast = isLast;
+        this.last = isLast;
     }
 
     public static EventsPagingResponse of(List<EventPagingInfo> content, boolean isLast){

--- a/src/test/java/lems/cowshed/config/RedisConfigTest.java
+++ b/src/test/java/lems/cowshed/config/RedisConfigTest.java
@@ -1,0 +1,24 @@
+package lems.cowshed.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest
+class RedisTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    void test() {
+        String key = "testKey";
+        String value = "Hello Upstash!";
+
+        redisTemplate.opsForValue().set(key, value);
+        String findValue = (String) redisTemplate.opsForValue().get(key);
+        Assertions.assertThat(value).isEqualTo(findValue);
+    }
+}


### PR DESCRIPTION
##
### 🌱 작업 내용
### 🚀 Redis 캐시를 활용한 조회 성능 최적화 및 비용 효율화

### 1. 개요
서비스에서 호출 빈도가 가장 높은 **모임 목록 첫 페이지**에 캐싱 전략 도입

---
### 2. 인프라 결정: Upstash
* **EC2 추가 후 직접 설치**: 서버 관리 공수가 발생하며, 추가 인스턴스 비용이 발생
* **AWS ElastiCache**: 고성능을 보장하지만, 고정적인 월 비용이 발생하여 초기 단계에서 부담이 크다
* **Upstash**: **Serverless 방식**으로 사용한 만큼만 비용을 지불하며 하루 1만건 무료 사용 가능

---
### 3. 캐싱 전략

#### **✅ Read: Cache-Aside (Look-aside)**
* **동작**: 데이터 조회 시 먼저 Redis 캐시를 확인 후 캐시에 데이터가 없으면 DB에서 데이터를 조회해와서 Redis에 저장
* **장점**: 실제 필요한 데이터만 캐시에 적재되어 메모리를 효율적으로 사용하며, Redis 장애 시에도 DB를 통해 서비스 지속 가능

#### **✅ Write: Write-Around**
* **동작**: 데이터 수정(Patch)이나 삭제 시 DB에만 업데이트를 수행하고, 기존에 생성된 캐시는 즉시 삭제
* **장점**: 데이터가 수정될 때마다 캐시를 무효화함으로써 조회 시점에 항상 최신 정합성이 보장된 데이터를 제공

---
### 4. 기대 효과
* **응답 속도 개선**: 반복적인 복잡한 페이징 쿼리를 메모리 조회로 대체하여 지연 시간(Latency) 단축.
* **비용 최적화**: 서버리스 Redis 도입을 통한 인프라 유지비 최소화.
* **데이터 정합성**: 수정 발생 시 자동 캐시 삭제를 통해 사용자에게 항상 최신 데이터 제공.

---
### 5. 적용 사진
[ 캐시 적용 X : 0.13초 ]
![캐시x](https://github.com/user-attachments/assets/2e0471de-7761-4004-94bb-305363a0003a)

---
[ 캐시 적용 O: 0.05초 ]
![캐싱](https://github.com/user-attachments/assets/f05c3299-e3b4-4ca1-9910-737010bbe6b3)
![첫 페이지 캐싱](https://github.com/user-attachments/assets/a79c2a89-05f4-4947-8407-8936fab97615)
