### PR TITLE
feat: 모임 첫 페이지 조회 캐싱 시간 변경

### DIFF
--- a/src/main/java/lems/cowshed/config/RedisConfig.java
+++ b/src/main/java/lems/cowshed/config/RedisConfig.java
@@ -58,7 +58,7 @@ public class RedisConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-                .entryTtl(Duration.ofMinutes(3));
+                .entryTtl(Duration.ofMinutes(30));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(cf)


### PR DESCRIPTION
##
### 🌱 작업 내용
### [ 모임 조회 첫 페이지 조회 캐싱 시간 변경 ]
- 변경: 3분 To 30분
- 사유: 모임 저장, 수정, 삭제 시 캐시 무효화 되기 때문에 캐싱 시간을 조금 더 길게 가져가도 된다고 판단