### PR TITLE
feat: 리프레시 토큰을 이용한 로그인 및 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/reissue/ReissueController.java
+++ b/src/main/java/lems/cowshed/api/controller/reissue/ReissueController.java
@@ -1,0 +1,45 @@
+package lems.cowshed.api.controller.reissue;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lems.cowshed.api.controller.CommonResponse;
+import lems.cowshed.global.exception.NotFoundException;
+import lems.cowshed.service.reissue.ReissueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import static lems.cowshed.global.exception.Message.USER_REFRESH_NOT_FOUND;
+import static lems.cowshed.global.exception.Reason.USER_REISSUE_FAIL;
+
+@RequiredArgsConstructor
+@RestController
+public class ReissueController {
+
+    private final ReissueService reissueService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<CommonResponse<Void>> reissue(HttpServletRequest request, HttpServletResponse response) {
+        String refresh = getRefreshCookie(request).orElseThrow(() -> new NotFoundException(USER_REISSUE_FAIL, USER_REFRESH_NOT_FOUND));
+        String newAccessToken = reissueService.reissue(refresh);
+        response.setHeader("Authorization", newAccessToken);
+        return new ResponseEntity<>(CommonResponse.success(), HttpStatus.OK);
+    }
+
+    private Optional<String> getRefreshCookie(HttpServletRequest request) {
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+        return Optional.ofNullable(refresh);
+    }
+}
+

--- a/src/main/java/lems/cowshed/config/RedisConfig.java
+++ b/src/main/java/lems/cowshed/config/RedisConfig.java
@@ -15,6 +15,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -44,6 +45,16 @@ public class RedisConfig {
                 .build();
 
         return new LettuceConnectionFactory(config, clientConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
     }
 
     @Bean

--- a/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
+++ b/src/main/java/lems/cowshed/config/jwt/JwtUtil.java
@@ -15,7 +15,7 @@ public class JwtUtil {
 
     private final SecretKey secretKey;
 
-    public JwtUtil(@Value("${spring.jwt.secret}")String secret) {
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
@@ -27,8 +27,8 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
     }
 
-    public String getUserEmail(String token){
-        return  Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    public String getUserEmail(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
     public Role getRole(String token) {
@@ -36,12 +36,17 @@ public class JwtUtil {
         return Role.valueOf(roleString);
     }
 
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
     public Boolean isExpired(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(Long id, String username, String email, String role, Long expiredMs) {
+    public String createJwt(String category, Long id, String username, String email, String role, Long expiredMs) {
         return Jwts.builder()
+                .claim("category", category)
                 .claim("id", id)
                 .claim("username", username)
                 .claim("email", email)

--- a/src/main/java/lems/cowshed/config/jwt/LogOutFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/LogOutFilter.java
@@ -1,0 +1,80 @@
+package lems.cowshed.config.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lems.cowshed.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class LogOutFilter extends GenericFilterBean {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("/users/logout")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        if (refreshRepository.isNotExists(refresh)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        refreshRepository.delete(refresh);
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
+++ b/src/main/java/lems/cowshed/config/jwt/LoginFilter.java
@@ -3,10 +3,13 @@ package lems.cowshed.config.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lems.cowshed.domain.user.CustomUserDetails;
+import lems.cowshed.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -26,6 +29,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
@@ -66,15 +70,29 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(userId, username, email, role, 30 * 24 * 60 * 60 * 1000L);
+        String accessToken = jwtUtil.createJwt("access", userId, username, email, role, 10 * 60 * 1000L);
+        String refresh = jwtUtil.createJwt("refresh", userId, username, email, role, 24 * 60 * 60 * 1000L);
 
-        response.addHeader("Authorization", "Bearer " + token);
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
 
+        // 레디스에 리프래시 토큰 저장
+        refreshTokenRepository.save(refresh);
     }
 
     //로그인 실패 시
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
         response.setStatus(401);
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
     }
 }

--- a/src/main/java/lems/cowshed/config/jwt/SecurityConfig.java
+++ b/src/main/java/lems/cowshed/config/jwt/SecurityConfig.java
@@ -1,5 +1,6 @@
 package lems.cowshed.config.jwt;
 
+import lems.cowshed.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -26,6 +28,7 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     //jwt 생성 클래스
     private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -76,6 +79,7 @@ public class SecurityConfig {
                         .requestMatchers("/users/signUp", "/users/login", "/users/verification/**", "/users/password-reset").permitAll()
                         .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/reissue").permitAll()
                         .anyRequest().authenticated());
 
         /*
@@ -84,10 +88,11 @@ public class SecurityConfig {
          Post 방식의 /login 요청을 받아 username, password 파라미터 처리
          AuthenticationManager 통해 자격 증명 인증 -> 성공 시 SecurityContextHolder 인증 객체를 저장 하여 세션 생성
          */
-        UsernamePasswordAuthenticationFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        UsernamePasswordAuthenticationFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshTokenRepository);
         loginFilter.setFilterProcessesUrl("/users/login");
 
         http
+                .addFilterBefore(new LogOutFilter(jwtUtil, refreshTokenRepository), LogoutFilter.class)
                 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class);
 
         /*

--- a/src/main/java/lems/cowshed/domain/user/Role.java
+++ b/src/main/java/lems/cowshed/domain/user/Role.java
@@ -1,5 +1,8 @@
 package lems.cowshed.domain.user;
 
+import lombok.Getter;
+
+@Getter
 public enum Role {
     ROLE_USER
 }

--- a/src/main/java/lems/cowshed/global/exception/Message.java
+++ b/src/main/java/lems/cowshed/global/exception/Message.java
@@ -12,6 +12,9 @@ public enum Message {
     USERNAME_EXIST("이미 존재하는 닉네임 입니다."),
     USERNAME_OR_EMAIL_EXIST("이미 존재하는 닉네임 혹은 이메일 입니다."),
     USER_NOT_CERTIFICATION_CODE("인증 코드가 일치 하지 않습니다."),
+    USER_REFRESH_NOT_FOUND("리프래쉬 토큰을 찾지 못했습니다"),
+    USER_REFRESH_NOT_EXPIRED("리프래쉬 토큰이 만료되었습니다"),
+    USER_REFRESH_NOT_MATCH_CATEGORY("토큰 종류가 일치하지 않습니다."),
 
     MAIL_SEND_ERROR("메일 보내기 실패 하였습니다."),
     MAIL_NOT_VALID_CERTIFICATION_CODE("유효 하지 않은 검증 코드 입니다."),

--- a/src/main/java/lems/cowshed/global/exception/Reason.java
+++ b/src/main/java/lems/cowshed/global/exception/Reason.java
@@ -12,6 +12,7 @@ public enum Reason {
     USER_PASSWORD("user_password"),
     USERNAME_OR_EMAIL("usernameOrEmail"),
     USER_CERTIFICATION_CODE("user_certification_code"),
+    USER_REISSUE_FAIL("user_reissue_fail"),
 
     MAIL("mail"),
     MAIL_CERTIFICATION_CODE("mail_certification_code"),

--- a/src/main/java/lems/cowshed/repository/RefreshTokenRepository.java
+++ b/src/main/java/lems/cowshed/repository/RefreshTokenRepository.java
@@ -1,0 +1,31 @@
+package lems.cowshed.repository;
+
+import lems.cowshed.config.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String refresh) {
+        long userId = jwtUtil.getUserId(refresh);
+        redisTemplate.opsForValue().set(String.valueOf(userId), refresh, Duration.ofDays(1));
+    }
+
+    public boolean isNotExists(String refresh) {
+        long userId = jwtUtil.getUserId(refresh);
+        return !redisTemplate.hasKey(String.valueOf(userId));
+    }
+
+    public void delete(String refresh) {
+        long userId = jwtUtil.getUserId(refresh);
+        redisTemplate.delete(String.valueOf(userId));
+    }
+}

--- a/src/main/java/lems/cowshed/service/reissue/ReissueService.java
+++ b/src/main/java/lems/cowshed/service/reissue/ReissueService.java
@@ -1,0 +1,51 @@
+package lems.cowshed.service.reissue;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import lems.cowshed.config.jwt.JwtUtil;
+import lems.cowshed.domain.user.Role;
+import lems.cowshed.global.exception.BusinessException;
+import lems.cowshed.global.exception.NotFoundException;
+import lems.cowshed.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static lems.cowshed.global.exception.Message.*;
+import static lems.cowshed.global.exception.Reason.USER_REISSUE_FAIL;
+
+@RequiredArgsConstructor
+@Service
+public class ReissueService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshRepository;
+
+    public String reissue(String refresh) {
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException ex) {
+            throw new BusinessException(USER_REISSUE_FAIL, USER_REFRESH_NOT_EXPIRED);
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+        if (isNotRefreshToken(category)) {
+            throw new BusinessException(USER_REISSUE_FAIL, USER_REFRESH_NOT_MATCH_CATEGORY);
+        }
+
+        if (refreshRepository.isNotExists(refresh)) {
+            throw new NotFoundException(USER_REISSUE_FAIL, USER_REFRESH_NOT_FOUND);
+        }
+        return createNewAccessToken(refresh);
+    }
+
+    private boolean isNotRefreshToken(String category) {
+        return !category.equals("refresh");
+    }
+
+    private String createNewAccessToken(String refresh) {
+        long userId = jwtUtil.getUserId(refresh);
+        String username = jwtUtil.getUsername(refresh);
+        String email = jwtUtil.getUserEmail(refresh);
+        Role role = jwtUtil.getRole(refresh);
+        return jwtUtil.createJwt("access", userId, username, email, role.name(), 10 * 60 * 1000L);
+    }
+}


### PR DESCRIPTION
##
### 🌱 작업 내용
### 🚀 Feature: Refresh Token 이용한 인증 구현

---

### 🛠 주요 구현 사항

### 1. 로그인 (토큰 발급 및 저장)
사용자 인증 성공 시 두 종류의 토큰을 발급하며, 상태 관리를 위해 Redis를 활용합니다.
* **Refresh Token 발급**: 보안을 위해 **쿠키(Cookie)** 저장 되도록 설정
* **Redis 저장**: `userId`를 Key로, 발급된 `refreshToken`을 Value로 하여 Redis에 저장

---
### 2. 토큰 재발급 API (Token Refresh)
Access Token이 만료되었을 때, Refresh Token을 이용하여 새로운 토큰을 발급받는 로직입니다.
* **검증 프로세스**
  - 클라이언트가 제출한 Refresh Token 확인
  - Redis에 해당 userId의 토큰이 존재하는지 대조
* **결과**: Redis에 저장된 토큰과 일치할 경우에만 Access Token을 재발급

---
### 3. 로그아웃 (Token Revocation)
* Redis에 저장된 해당 유저의 **Refresh Token 삭제**
* **결과**: 로그아웃 이후에는 기존 Refresh Token 재발급이 불가능하도록 차단

---

## 🔍 로직 요약 표

| 구분 | 처리 내용 | 비고 |
| :--- | :--- | :--- |
| **로그인** | Redis에 `userId:refreshToken` 저장 | 쿠키에 토큰 전달 |
| **재발급** | Redis 내 토큰 존재 여부 확인 후 발급 | Redis에 없으면 거부 |
| **로그아웃** | Redis 내 해당 `userId` 키 삭제 | 재발급 차단 |

---
## 토큰 유효기간
- **Refresh Token** : 1일
- **Access Token** : 10분