### PR TITLE
feat: 모임 첫 페이지 캐시 리팩토링

### DIFF
--- a/src/main/java/lems/cowshed/api/controller/event/EventController.java
+++ b/src/main/java/lems/cowshed/api/controller/event/EventController.java
@@ -9,8 +9,6 @@ import lems.cowshed.dto.event.request.EventUpdateRequestDto;
 import lems.cowshed.dto.event.response.*;
 import lems.cowshed.service.event.EventService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
@@ -34,7 +32,6 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(response);
     }
 
-    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @Counted(value = "event.create", description = "모임 생성")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<Long> saveEvent(@ModelAttribute @Validated EventSaveRequestDto requestDto,
@@ -43,7 +40,6 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(eventId);
     }
 
-    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @PatchMapping("/{event-id}")
     public CommonResponse<Void> editEvent(@PathVariable("event-id") Long eventId,
                                           @ModelAttribute @Validated EventUpdateRequestDto requestDto,
@@ -58,7 +54,6 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(participantsInfo);
     }
 
-    @Cacheable(value = "eventFirstPage", key = "'page0'", condition = "#pageable.pageNumber == 0")
     @GetMapping
     public CommonResponse<EventsPagingResponse> getEventsPaging(@PageableDefault(page = 0, size = 10) Pageable pageable,
                                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -101,7 +96,6 @@ public class EventController implements EventSpecification {
         return CommonResponse.success(count);
     }
 
-    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     @DeleteMapping("/{event-id}")
     public CommonResponse<Void> deleteEvent(@PathVariable("event-id") Long eventId,
                                             @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/lems/cowshed/config/RedisConfig.java
+++ b/src/main/java/lems/cowshed/config/RedisConfig.java
@@ -69,7 +69,7 @@ public class RedisConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-                .entryTtl(Duration.ofMinutes(30));
+                .entryTtl(Duration.ofMinutes(1));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(cf)

--- a/src/main/java/lems/cowshed/service/event/EventService.java
+++ b/src/main/java/lems/cowshed/service/event/EventService.java
@@ -30,7 +30,11 @@ import lems.cowshed.repository.regular.event.RegularEventRepository;
 import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
 import lems.cowshed.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +43,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static lems.cowshed.domain.bookmark.BookmarkStatus.BOOKMARK;
@@ -59,6 +64,8 @@ public class EventService {
     private final RegularEventRepository regularEventRepository;
     private final RegularEventParticipationRepository regularEventParticipationRepository;
     private final AwsS3Util awsS3Util;
+    private final CacheManager cacheManager;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public EventInfo getEvent(Long eventId, String username) {
         Event event = eventRepository.findById(eventId)
@@ -75,6 +82,7 @@ public class EventService {
     }
 
     @Transactional
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     public Long saveEvent(EventSaveRequestDto requestDto, String username) throws IOException {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(USER_NAME, USER_NOT_FOUND));
@@ -89,6 +97,7 @@ public class EventService {
     }
 
     @Transactional
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     public void editEvent(Long eventId, EventUpdateRequestDto request, String username) throws IOException {
         Event event = eventRepository.findByIdAndAuthor(eventId, username)
                 .orElseThrow(() -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));
@@ -129,23 +138,28 @@ public class EventService {
     }
 
     public EventsPagingResponse getEventsPaging(Pageable pageable, Long userId) {
-        Slice<Event> eventsToLookFor = eventRepository.findEventsBy(pageable);
+        if (pageable.getPageNumber() != 0) {
+            return fetchEventsPagingFromDb(pageable, userId);
+        }
 
-        List<Event> content = eventsToLookFor.getContent();
-        Events events = Events.of(content);
-        List<Long> eventIds = events.extractIds();
+        Cache cache = cacheManager.getCache("eventFirstPage");
+        Cache.ValueWrapper cached = cache.get("page0");
+        Long remainingTtlMs = redisTemplate.getExpire("eventFirstPage::page0", TimeUnit.MILLISECONDS);
 
-        List<EventParticipation> participatedEvent = eventParticipantRepository.findEventParticipationByEventIdIn(eventIds);
-        Participants participants = Participants.of(participatedEvent);
-        Map<Long, Long> participantsCountByGroupId = participants.findNumberOfParticipants();
+        if (cached != null && isCacheAlive(remainingTtlMs)) {
+            if (isNotPerTarget(remainingTtlMs)) {
+                return (EventsPagingResponse) cached.get();
+            }
+            redisTemplate.expire("eventFirstPage::page0", 1, TimeUnit.MINUTES);
+        }
 
-        Set<Long> userBookmarkedEventIds = eventRepository.findEventIdsBookmarkedByUser(userId, eventIds, BOOKMARK);
-        List<EventPagingInfo> result = createEventSimpleInfo(content, participantsCountByGroupId, userBookmarkedEventIds);
-
-        return EventsPagingResponse.of(result, eventsToLookFor.isLast());
+        EventsPagingResponse result = fetchEventsPagingFromDb(pageable, userId);
+        cache.put("page0", result);
+        return result;
     }
 
     @Transactional
+    @CacheEvict(value = "eventFirstPage", key = "'page0'")
     public void deleteEvent(Long eventId, String username) {
         Event event = eventRepository.findByIdAndAuthor(eventId, username).orElseThrow(
                 () -> new NotFoundException(EVENT_ID, EVENT_NOT_FOUND));
@@ -191,6 +205,33 @@ public class EventService {
 
     public int searchEventsCount(EventSearchCondition condition) {
         return eventQueryRepository.searchCount(condition.getContent(), condition.getCategory());
+    }
+
+    private boolean isCacheAlive(Long remainingTtlMs) {
+        return remainingTtlMs != null && remainingTtlMs > 0;
+    }
+
+    private boolean isNotPerTarget(Long remainingTtlMs) {
+        double beta = 1.0;
+        double deltaMs = 4000.0;
+        return Math.random() >= Math.exp(-(double) remainingTtlMs / (deltaMs * beta));
+    }
+
+    private EventsPagingResponse fetchEventsPagingFromDb(Pageable pageable, Long userId) {
+        Slice<Event> eventsToLookFor = eventRepository.findEventsBy(pageable);
+
+        List<Event> content = eventsToLookFor.getContent();
+        Events events = Events.of(content);
+        List<Long> eventIds = events.extractIds();
+
+        List<EventParticipation> participatedEvent = eventParticipantRepository.findEventParticipationByEventIdIn(eventIds);
+        Participants participants = Participants.of(participatedEvent);
+        Map<Long, Long> participantsCountByGroupId = participants.findNumberOfParticipants();
+
+        Set<Long> userBookmarkedEventIds = eventRepository.findEventIdsBookmarkedByUser(userId, eventIds, BOOKMARK);
+        List<EventPagingInfo> result = createEventSimpleInfo(content, participantsCountByGroupId, userBookmarkedEventIds);
+
+        return EventsPagingResponse.of(result, eventsToLookFor.isLast());
     }
 
     private List<Long> getEventsId(List<Event> events) {

--- a/src/test/java/lems/cowshed/service/event/EventServiceTest.java
+++ b/src/test/java/lems/cowshed/service/event/EventServiceTest.java
@@ -1,29 +1,31 @@
 package lems.cowshed.service.event;
 
 import lems.cowshed.IntegrationTestSupport;
+import lems.cowshed.domain.bookmark.Bookmark;
 import lems.cowshed.domain.event.Category;
+import lems.cowshed.domain.event.Event;
+import lems.cowshed.domain.event.participation.EventParticipation;
+import lems.cowshed.domain.regular.event.RegularEvent;
+import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
+import lems.cowshed.domain.user.Mbti;
+import lems.cowshed.domain.user.User;
 import lems.cowshed.dto.event.request.EventSaveRequestDto;
 import lems.cowshed.dto.event.request.EventSearchCondition;
 import lems.cowshed.dto.event.request.EventUpdateRequestDto;
 import lems.cowshed.dto.event.response.*;
 import lems.cowshed.dto.regular.event.response.RegularEventInfo;
-import lems.cowshed.domain.bookmark.Bookmark;
-import lems.cowshed.repository.bookmark.BookmarkRepository;
-import lems.cowshed.domain.event.Event;
-import lems.cowshed.repository.event.EventRepository;
-import lems.cowshed.domain.event.participation.EventParticipation;
-import lems.cowshed.domain.regular.event.RegularEvent;
-import lems.cowshed.repository.regular.event.RegularEventRepository;
-import lems.cowshed.domain.regular.event.participation.RegularEventParticipation;
-import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
-import lems.cowshed.domain.user.Mbti;
-import lems.cowshed.domain.user.User;
-import lems.cowshed.repository.user.UserRepository;
-import lems.cowshed.repository.event.participation.EventParticipantRepository;
 import lems.cowshed.global.exception.BusinessException;
 import lems.cowshed.global.exception.NotFoundException;
+import lems.cowshed.repository.bookmark.BookmarkRepository;
+import lems.cowshed.repository.event.EventRepository;
+import lems.cowshed.repository.event.participation.EventParticipantRepository;
+import lems.cowshed.repository.regular.event.RegularEventRepository;
+import lems.cowshed.repository.regular.event.participation.RegularEventParticipationRepository;
+import lems.cowshed.repository.user.UserRepository;
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,11 +34,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static lems.cowshed.domain.bookmark.BookmarkStatus.*;
-import static lems.cowshed.domain.user.Mbti.*;
-import static org.assertj.core.api.Assertions.*;
+import static lems.cowshed.domain.bookmark.BookmarkStatus.BOOKMARK;
+import static lems.cowshed.domain.bookmark.BookmarkStatus.NOT_BOOKMARK;
+import static lems.cowshed.domain.user.Mbti.INTP;
+import static lems.cowshed.domain.user.Mbti.ISTP;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EventServiceTest extends IntegrationTestSupport {
 
@@ -351,7 +355,7 @@ class EventServiceTest extends IntegrationTestSupport {
         assertThat(regularEvents)
                 .extracting("isRegularRegistrant")
                 .containsExactlyInAnyOrder(
-                        true,false
+                        true, false
                 );
     }
 
@@ -364,7 +368,7 @@ class EventServiceTest extends IntegrationTestSupport {
 
         int userCount = 2;
 
-        for(int i = 0; i < userCount; i++){
+        for (int i = 0; i < userCount; i++) {
             User user = createUser("테스터", "testEmail");
             userRepository.save(user);
             eventParticipationService.saveEventParticipation(event.getId(), user.getId());
@@ -528,7 +532,7 @@ class EventServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         int bookmarkCount = 3;
-        for(int i = 0; i < bookmarkCount; i++){
+        for (int i = 0; i < bookmarkCount; i++) {
             Event event = createEvent(author, "테스트" + i);
             eventRepository.save(event);
 
@@ -583,9 +587,9 @@ class EventServiceTest extends IntegrationTestSupport {
         User user = createUser("테스터", "test@naver.com");
         userRepository.save(user);
 
-        Event event = createEvent("테스터", "모임" , "내용", Category.GAME);
+        Event event = createEvent("테스터", "모임", "내용", Category.GAME);
         Event event2 = createEvent("테스터", "모임2", "내용2", Category.HOBBY);
-        eventRepository.saveAll(List.of(event,event2));
+        eventRepository.saveAll(List.of(event, event2));
 
         EventSearchCondition searchCondition = createSearchCondition(null, null);
 
@@ -616,7 +620,7 @@ class EventServiceTest extends IntegrationTestSupport {
         String searchKeyword = "검색";
         Event event = createEvent("테스터", "모임 " + searchKeyword, "내용", Category.GAME);
         Event event2 = createEvent("테스터", "모임", "내용", Category.HOBBY);
-        eventRepository.saveAll(List.of(event,event2));
+        eventRepository.saveAll(List.of(event, event2));
 
         EventSearchCondition searchCondition = createSearchCondition(searchKeyword, null);
 
@@ -644,7 +648,7 @@ class EventServiceTest extends IntegrationTestSupport {
         Category searchCategory = Category.HOBBY;
         Event event = createEvent("테스터", "모임", "내용", Category.GAME);
         Event event2 = createEvent("테스터", "모임2", "내용2", Category.HOBBY);
-        eventRepository.saveAll(List.of(event,event2));
+        eventRepository.saveAll(List.of(event, event2));
 
         EventSearchCondition searchCondition = createSearchCondition(null, searchCategory);
 
@@ -673,9 +677,9 @@ class EventServiceTest extends IntegrationTestSupport {
         Category searchCategory = Category.PET;
         Event event = createEvent("테스터", "모임 " + searchKeyword, "내용", Category.GAME);
 
-        Event event2 = createEvent("테스터", "모임2" , "내용 " + searchKeyword, searchCategory);
+        Event event2 = createEvent("테스터", "모임2", "내용 " + searchKeyword, searchCategory);
         Event event3 = createEvent("테스터", "모임3", "내용", searchCategory);
-        eventRepository.saveAll(List.of(event,event2, event3));
+        eventRepository.saveAll(List.of(event, event2, event3));
 
         EventSearchCondition searchCondition = createSearchCondition(searchKeyword, searchCategory);
 
@@ -766,7 +770,7 @@ class EventServiceTest extends IntegrationTestSupport {
                 );
     }
 
-    private static EventSearchCondition createSearchCondition(String content, Category category){
+    private static EventSearchCondition createSearchCondition(String content, Category category) {
         return EventSearchCondition.builder()
                 .content(content)
                 .category(category)
@@ -780,7 +784,7 @@ class EventServiceTest extends IntegrationTestSupport {
                 .build();
     }
 
-    private static Event createEvent(String author, String name, String content, Category category){
+    private static Event createEvent(String author, String name, String content, Category category) {
         return Event.builder()
                 .name(name)
                 .author(author)
@@ -833,7 +837,7 @@ class EventServiceTest extends IntegrationTestSupport {
                 .build();
     }
 
-    private RegularEvent createRegularEvent(Event event, String name, String location, Long userId){
+    private RegularEvent createRegularEvent(Event event, String name, String location, Long userId) {
         return RegularEvent.builder()
                 .event(event)
                 .name(name)
@@ -843,7 +847,7 @@ class EventServiceTest extends IntegrationTestSupport {
                 .build();
     }
 
-    private RegularEventParticipation createRegularParticipation(Long userId, RegularEvent regularEvent){
+    private RegularEventParticipation createRegularParticipation(Long userId, RegularEvent regularEvent) {
         return RegularEventParticipation.of(userId, regularEvent.getId());
     }
 }


### PR DESCRIPTION
### 🌱 작업 내용
이벤트 목록 첫 페이지 캐싱 로직에 **PER (Probabilistic Early Recomputation) 알고리즘**을 적용

#### 1. PER 알고리즘 적용
캐시 만료 시점에 가까워질수록 확률적으로 미리 캐시를 갱신하도록 변경

```java
private boolean isNotPerTarget(Long remainingTtlMs) {
    double beta = 1.0;
    double deltaMs = 4000.0;
    return Math.random() >= Math.exp(-(double) remainingTtlMs / (deltaMs * beta));
}
```

**적용 이유: Cache Stampede 현상 방지**

- 기존 방식은 캐시가 만료되는 순간, 동시에 들어온 다수의 요청이 모두 캐시 미스를 겪고 한꺼번에 DB로 몰리는 Cache Stampede 현상이 발생 가능
-  PER 알고리즘은 만료 시점 이전에 확률적으로 캐시를 미리 갱신함으로써 이러한 트래픽 집중을 자연스럽게 분산

#### 2. TTL 30분 → 1분 변경

- 캐시 저장과 캐시 삭제 동작이 동시에 일어날 경우, 캐시 저장 시점에 이미 stale한 이전 데이터가 캐시될 수 있는 문제가 발생 가능
- TTL을 1분으로 짧게 가져가 stale 데이터가 캐시에 머무르는 시간을 최소화

##
### 🔎 스크린 샷

#### PER 알고리즘 갱신 확률 분포

`deltaMs = 4초`, `beta = 1.0` 기준, 남은 TTL에 따른 캐시 갱신 발동 확률입니다.

| 남은 TTL | exp(-t/4000) | 갱신 확률 |
|:-------:|:------------:|:--------:|
| 60초 | 0.0000 | 0% |
| 30초 | 0.0006 | 0.06% |
| 20초 | 0.0067 | 0.67% |
| 15초 | 0.0235 | 2.4% |
| 10초 | 0.0821 | 8.2% |
| 7초 | 0.1738 | 17.4% |
| 5초 | 0.2865 | 28.6% |
| 3초 | 0.4724 | 47.2% |
| 2초 | 0.6065 | 60.7% |
| 1초 | 0.7788 | 77.9% |
| 0초 | 1.0000 | 100% (즉시 갱신) |

만료가 가까워질수록 갱신 확률이 점진적으로 상승하여, 특정 시점에 트래픽이 몰리지 않고 자연스럽게 분산